### PR TITLE
fix dspm roles unique id not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ Key features:
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS 12 digit account ID | `string` | `""` | no |
 | <a name="input_account_type"></a> [account\_type](#input\_account\_type) | Account type can be either 'commercial' or 'gov' | `string` | `"commercial"` | no |
 | <a name="input_cloudtrail_bucket_name"></a> [cloudtrail\_bucket\_name](#input\_cloudtrail\_bucket\_name) | n/a | `string` | `""` | no |
+| <a name="input_dspm_integration_role_unique_id"></a> [dspm\_integration\_role\_unique\_id](#input\_dspm\_integration\_role\_unique\_id) | The unique ID of the DSPM integration role | `string` | `""` | no |
 | <a name="input_dspm_regions"></a> [dspm\_regions](#input\_dspm\_regions) | The regions in which DSPM scanning environments will be created | `list(string)` | <pre>[<br/>  "us-east-1"<br/>]</pre> | no |
 | <a name="input_dspm_role_name"></a> [dspm\_role\_name](#input\_dspm\_role\_name) | The unique name of the IAM role that DSPM will be assuming | `string` | `"CrowdStrikeDSPMIntegrationRole"` | no |
 | <a name="input_dspm_scanner_role_name"></a> [dspm\_scanner\_role\_name](#input\_dspm\_scanner\_role\_name) | The unique name of the IAM role that CrowdStrike Scanner will be assuming | `string` | `"CrowdStrikeDSPMScannerRole"` | no |
+| <a name="input_dspm_scanner_role_unique_id"></a> [dspm\_scanner\_role\_unique\_id](#input\_dspm\_scanner\_role\_unique\_id) | The unique ID of the DSPM scanner role | `string` | `""` | no |
 | <a name="input_enable_dspm"></a> [enable\_dspm](#input\_enable\_dspm) | Set to true to enable Data Security Posture Managment | `bool` | `false` | no |
 | <a name="input_enable_idp"></a> [enable\_idp](#input\_enable\_idp) | Set to true to install Identity Protection resources | `bool` | `false` | no |
 | <a name="input_enable_realtime_visibility"></a> [enable\_realtime\_visibility](#input\_enable\_realtime\_visibility) | Set to true to install realtime visibility resources | `bool` | `false` | no |
@@ -99,7 +101,10 @@ Key features:
 | <a name="input_use_existing_cloudtrail"></a> [use\_existing\_cloudtrail](#input\_use\_existing\_cloudtrail) | Set to true if you already have a cloudtrail | `bool` | `false` | no |
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_integration_role_unique_id"></a> [integration\_role\_unique\_id](#output\_integration\_role\_unique\_id) | The unique ID of the DSPM integration role |
+| <a name="output_scanner_role_unique_id"></a> [scanner\_role\_unique\_id](#output\_scanner\_role\_unique\_id) | The unique ID of the DSPM scanner role |
 
 ## Usage
 

--- a/examples/org-aws-profile/main.tf
+++ b/examples/org-aws-profile/main.tf
@@ -15,9 +15,8 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id                         = var.account_id
-  organization_id                    = var.organization_id
-  is_organization_management_account = true
+  account_id      = var.account_id
+  organization_id = var.organization_id
 
   asset_inventory = {
     enabled = true
@@ -88,7 +87,7 @@ module "fcs_child_account_1" {
   enable_dspm                 = local.enable_dspm
   dspm_regions                = local.dspm_regions
 
-  iam_role_name           = crowdstrike_cloud_aws_account.this.iam_role_name
+  iam_role_name          = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id            = crowdstrike_cloud_aws_account.this.external_id
   intermediate_role_arn  = crowdstrike_cloud_aws_account.this.intermediate_role_arn
   eventbus_arn           = crowdstrike_cloud_aws_account.this.eventbus_arn

--- a/examples/org-aws-role/main.tf
+++ b/examples/org-aws-role/main.tf
@@ -15,9 +15,8 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id                         = var.account_id
-  organization_id                    = var.organization_id
-  is_organization_management_account = true
+  account_id      = var.account_id
+  organization_id = var.organization_id
 
   asset_inventory = {
     enabled = true

--- a/examples/single-account-provider/main.tf
+++ b/examples/single-account-provider/main.tf
@@ -58,7 +58,7 @@ resource "crowdstrike_cloud_aws_account" "this" {
 }
 
 module "fcs_account_onboarding" {
-  source                     = "CrowdStrike/fcs/aws"
+  source                     = "../../"
   falcon_client_id           = var.falcon_client_id
   falcon_client_secret       = var.falcon_client_secret
   account_id                 = var.account_id
@@ -74,6 +74,7 @@ module "fcs_account_onboarding" {
   external_id            = crowdstrike_cloud_aws_account.this.external_id
   intermediate_role_arn  = crowdstrike_cloud_aws_account.this.intermediate_role_arn
   eventbus_arn           = crowdstrike_cloud_aws_account.this.eventbus_arn
+  dspm_role_name         = crowdstrike_cloud_aws_account.this.dspm_role_name
   cloudtrail_bucket_name = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
 
   providers = {
@@ -83,7 +84,7 @@ module "fcs_account_onboarding" {
 }
 
 module "fcs_account_us-east-2" {
-  source                     = "CrowdStrike/fcs/aws"
+  source                     = "../.."
   falcon_client_id           = var.falcon_client_id
   falcon_client_secret       = var.falcon_client_secret
   account_id                 = var.account_id
@@ -95,11 +96,14 @@ module "fcs_account_us-east-2" {
   enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-east-2")
   dspm_regions               = local.dspm_regions
 
-  iam_role_name          = crowdstrike_cloud_aws_account.this.iam_role_name
-  external_id            = crowdstrike_cloud_aws_account.this.external_id
-  intermediate_role_arn  = crowdstrike_cloud_aws_account.this.intermediate_role_arn
-  eventbus_arn           = crowdstrike_cloud_aws_account.this.eventbus_arn
-  cloudtrail_bucket_name = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
+  iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
+  external_id                     = crowdstrike_cloud_aws_account.this.external_id
+  intermediate_role_arn           = crowdstrike_cloud_aws_account.this.intermediate_role_arn
+  eventbus_arn                    = crowdstrike_cloud_aws_account.this.eventbus_arn
+  dspm_role_name                  = crowdstrike_cloud_aws_account.this.dspm_role_name
+  cloudtrail_bucket_name          = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
+  dspm_integration_role_unique_id = module.fcs_account_onboarding.integration_role_unique_id
+  dspm_scanner_role_unique_id     = module.fcs_account_onboarding.scanner_role_unique_id
 
   providers = {
     aws         = aws.us-east-2
@@ -108,7 +112,7 @@ module "fcs_account_us-east-2" {
 }
 
 module "fcs_account_us-west-1" {
-  source                     = "CrowdStrike/fcs/aws"
+  source                     = "../.."
   falcon_client_id           = var.falcon_client_id
   falcon_client_secret       = var.falcon_client_secret
   account_id                 = var.account_id
@@ -120,11 +124,14 @@ module "fcs_account_us-west-1" {
   enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-west-1")
   dspm_regions               = local.dspm_regions
 
-  iam_role_name          = crowdstrike_cloud_aws_account.this.iam_role_name
-  external_id            = crowdstrike_cloud_aws_account.this.external_id
-  intermediate_role_arn  = crowdstrike_cloud_aws_account.this.intermediate_role_arn
-  eventbus_arn           = crowdstrike_cloud_aws_account.this.eventbus_arn
-  cloudtrail_bucket_name = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
+  iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
+  external_id                     = crowdstrike_cloud_aws_account.this.external_id
+  intermediate_role_arn           = crowdstrike_cloud_aws_account.this.intermediate_role_arn
+  eventbus_arn                    = crowdstrike_cloud_aws_account.this.eventbus_arn
+  dspm_role_name                  = crowdstrike_cloud_aws_account.this.dspm_role_name
+  cloudtrail_bucket_name          = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
+  dspm_integration_role_unique_id = module.fcs_account_onboarding.integration_role_unique_id
+  dspm_scanner_role_unique_id     = module.fcs_account_onboarding.scanner_role_unique_id
 
   providers = {
     aws         = aws.us-west-1
@@ -133,7 +140,7 @@ module "fcs_account_us-west-1" {
 }
 
 module "fcs_account_us-west-2" {
-  source                     = "CrowdStrike/fcs/aws"
+  source                     = "../.."
   falcon_client_id           = var.falcon_client_id
   falcon_client_secret       = var.falcon_client_secret
   account_id                 = var.account_id
@@ -145,11 +152,14 @@ module "fcs_account_us-west-2" {
   enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-west-2")
   dspm_regions               = local.dspm_regions
 
-  iam_role_name          = crowdstrike_cloud_aws_account.this.iam_role_name
-  external_id            = crowdstrike_cloud_aws_account.this.external_id
-  intermediate_role_arn  = crowdstrike_cloud_aws_account.this.intermediate_role_arn
-  eventbus_arn           = crowdstrike_cloud_aws_account.this.eventbus_arn
-  cloudtrail_bucket_name = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
+  iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
+  external_id                     = crowdstrike_cloud_aws_account.this.external_id
+  intermediate_role_arn           = crowdstrike_cloud_aws_account.this.intermediate_role_arn
+  eventbus_arn                    = crowdstrike_cloud_aws_account.this.eventbus_arn
+  dspm_role_name                  = crowdstrike_cloud_aws_account.this.dspm_role_name
+  cloudtrail_bucket_name          = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
+  dspm_integration_role_unique_id = module.fcs_account_onboarding.integration_role_unique_id
+  dspm_scanner_role_unique_id     = module.fcs_account_onboarding.scanner_role_unique_id
 
   providers = {
     aws         = aws.us-west-2

--- a/examples/single-account-provider/variables.tf
+++ b/examples/single-account-provider/variables.tf
@@ -15,7 +15,7 @@ variable "account_id" {
   default     = ""
   description = "The AWS 12 digit account ID"
   validation {
-    condition     = length(var.account_id) == 0 || can(regex("^[0-9]{12}$", var.account_id))
+    condition     = can(regex("^[0-9]{12}$", var.account_id))
     error_message = "account_id must be either empty or the 12-digit AWS account ID"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -98,10 +98,11 @@ module "dspm_roles" {
 }
 
 module "dspm_environments" {
-  count                  = var.enable_dspm ? 1 : 0
-  source                 = "./modules/dspm-environments/"
-  dspm_role_name         = var.dspm_role_name
-  dspm_scanner_role_name = var.dspm_scanner_role_name
+  count                      = var.enable_dspm && contains(var.dspm_regions, local.aws_region) ? 1 : 0
+  source                     = "./modules/dspm-environments/"
+  dspm_role_name             = var.dspm_role_name
+  integration_role_unique_id = local.is_primary_region ? module.dspm_roles.0.integration_role_unique_id : var.dspm_integration_role_unique_id
+  scanner_role_unique_id     = local.is_primary_region ? module.dspm_roles.0.scanner_role_unique_id : var.dspm_scanner_role_unique_id
 
   depends_on = [module.dspm_roles]
 

--- a/modules/realtime-visibility/govcom.tf
+++ b/modules/realtime-visibility/govcom.tf
@@ -170,6 +170,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3" {
   rule {
     id     = "rule-1"
     status = "Enabled"
+    filter {
+      prefix = ""
+    }
     expiration {
       days = 1
     }

--- a/modules/registration-profile/README.md
+++ b/modules/registration-profile/README.md
@@ -104,9 +104,8 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id                         = var.account_id
-  organization_id                    = local.organization_id
-  is_organization_management_account = true
+  account_id      = var.account_id
+  organization_id = local.organization_id
 
   asset_inventory = {
     enabled = true

--- a/modules/registration-profile/docs/.usage.tf
+++ b/modules/registration-profile/docs/.usage.tf
@@ -52,9 +52,8 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id                         = var.account_id
-  organization_id                    = local.organization_id
-  is_organization_management_account = true
+  account_id      = var.account_id
+  organization_id = local.organization_id
 
   asset_inventory = {
     enabled = true

--- a/modules/registration-profile/main.tf
+++ b/modules/registration-profile/main.tf
@@ -58,11 +58,11 @@ module "sensor_management" {
 module "dspm_roles" {
   count                  = (var.enable_dspm && !var.is_gov) ? 1 : 0
   source                 = "../dspm-roles/"
-  dspm_role_name         = var.dspm_role_name
-  dspm_scanner_role_name = var.dspm_scanner_role_name
-  intermediate_role_arn  = var.intermediate_role_arn
   falcon_client_id       = var.falcon_client_id
   falcon_client_secret   = var.falcon_client_secret
-  external_id            = var.external_id
+  dspm_role_name         = var.dspm_role_name
+  dspm_scanner_role_name = var.dspm_scanner_role_name
+  intermediate_role_arn  = local.intermediate_role_arn
+  external_id            = local.external_id
   dspm_regions           = var.dspm_regions
 }

--- a/modules/registration-role/README.md
+++ b/modules/registration-role/README.md
@@ -96,9 +96,8 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id                         = local.management_account_id
-  organization_id                    = local.organization_id
-  is_organization_management_account = true
+  account_id      = local.management_account_id
+  organization_id = local.organization_id
 
   asset_inventory = {
     enabled = true

--- a/modules/registration-role/docs/.usage.tf
+++ b/modules/registration-role/docs/.usage.tf
@@ -44,9 +44,8 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id                         = local.management_account_id
-  organization_id                    = local.organization_id
-  is_organization_management_account = true
+  account_id      = local.management_account_id
+  organization_id = local.organization_id
 
   asset_inventory = {
     enabled = true

--- a/modules/registration-role/main.tf
+++ b/modules/registration-role/main.tf
@@ -71,11 +71,11 @@ module "sensor_management" {
 module "dspm_roles" {
   count                  = (var.enable_dspm && !var.is_gov) ? 1 : 0
   source                 = "../dspm-roles/"
-  dspm_role_name         = var.dspm_role_name
-  dspm_scanner_role_name = var.dspm_scanner_role_name
-  intermediate_role_arn  = var.intermediate_role_arn
   falcon_client_id       = var.falcon_client_id
   falcon_client_secret   = var.falcon_client_secret
+  dspm_role_name         = var.dspm_role_name
+  dspm_scanner_role_name = var.dspm_scanner_role_name
+  intermediate_role_arn  = local.intermediate_role_arn
   external_id            = local.external_id
   dspm_regions           = var.dspm_regions
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "integration_role_unique_id" {
+  description = "The unique ID of the DSPM integration role"
+  value       = try(module.dspm_roles.0.integration_role_unique_id, "")
+}
+
+output "scanner_role_unique_id" {
+  description = "The unique ID of the DSPM scanner role"
+  value       = try(module.dspm_roles.0.scanner_role_unique_id, "")
+}

--- a/variables.tf
+++ b/variables.tf
@@ -149,3 +149,15 @@ variable "dspm_regions" {
     error_message = "Each element in the dspm_regions list must be a valid AWS region (e.g., 'us-east-1', 'eu-west-2') that is supported by DSPM."
   }
 }
+
+variable "dspm_integration_role_unique_id" {
+  description = "The unique ID of the DSPM integration role"
+  default     = ""
+  type        = string
+}
+
+variable "dspm_scanner_role_unique_id" {
+  description = "The unique ID of the DSPM scanner role"
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
When using bring your own provider example with DSPM feature deployed in multiple regions the roles were missing.

Added optional variables and outputs that need to be passed from the primary region of DSPM to the secondary region modules (see example)