### PR TITLE
add realtime_visibility_regions variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ module "fcs_account_us_east_2" {
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The AWS Organization ID. Leave blank if when onboarding single account | `string` | `""` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The name of the policy used to set the permissions boundary for IAM roles | `string` | `""` | no |
 | <a name="input_primary_region"></a> [primary\_region](#input\_primary\_region) | Region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. Distinct from dspm\_regions which controls region-specific resource deployment. | `string` | n/a | yes |
+| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions where Real-time visibility and detection should be enabled. Use ["all"] to onboard all regions | `list(string)` | <pre>[<br/>  "all"<br/>]</pre> | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix to be added to all resource names | `string` | `"CrowdStrike"` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to be added to all resource names | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources that support tagging | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ module "fcs_account_us_east_2" {
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS 12 digit account ID | `string` | `""` | no |
 | <a name="input_account_type"></a> [account\_type](#input\_account\_type) | Account type can be either 'commercial' or 'gov' | `string` | `"commercial"` | no |
 | <a name="input_cloudtrail_bucket_name"></a> [cloudtrail\_bucket\_name](#input\_cloudtrail\_bucket\_name) | Name of the S3 bucket for CloudTrail logs | `string` | `""` | no |
+| <a name="input_create_rtvd_rules"></a> [create\_rtvd\_rules](#input\_create\_rtvd\_rules) | Set to false if you don't want to enable monitoring in this region | `bool` | `true` | no |
 | <a name="input_dspm_integration_role_unique_id"></a> [dspm\_integration\_role\_unique\_id](#input\_dspm\_integration\_role\_unique\_id) | The unique ID of the DSPM integration role | `string` | `""` | no |
 | <a name="input_dspm_regions"></a> [dspm\_regions](#input\_dspm\_regions) | The regions in which DSPM scanning environments will be created | `list(string)` | <pre>[<br/>  "us-east-1"<br/>]</pre> | no |
 | <a name="input_dspm_role_name"></a> [dspm\_role\_name](#input\_dspm\_role\_name) | The unique name of the IAM role that DSPM will be assuming | `string` | `"CrowdStrikeDSPMIntegrationRole"` | no |
@@ -255,7 +256,6 @@ module "fcs_account_us_east_2" {
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The AWS Organization ID. Leave blank if when onboarding single account | `string` | `""` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The name of the policy used to set the permissions boundary for IAM roles | `string` | `""` | no |
 | <a name="input_primary_region"></a> [primary\_region](#input\_primary\_region) | Region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. Distinct from dspm\_regions which controls region-specific resource deployment. | `string` | n/a | yes |
-| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions where Real-time visibility and detection should be enabled. Use ["all"] to onboard all regions | `list(string)` | <pre>[<br/>  "all"<br/>]</pre> | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix to be added to all resource names | `string` | `"CrowdStrike"` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to be added to all resource names | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources that support tagging | `map(string)` | `{}` | no |

--- a/examples/single-account-aws-profile/main.tf
+++ b/examples/single-account-aws-profile/main.tf
@@ -79,7 +79,6 @@ module "fcs_account" {
   cloudtrail_bucket_name = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
   dspm_scanner_role_name = local.dspm_scanner_role_name
 
-
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix
   tags            = local.tags

--- a/examples/single-account-aws-profile/variables.tf
+++ b/examples/single-account-aws-profile/variables.tf
@@ -24,3 +24,9 @@ variable "aws_profile" {
   type        = string
   description = "The AWS profile to be used for this registration"
 }
+
+variable "me" {
+  type        = string
+  default     = "unspecified"
+  description = "The user running terraform"
+}

--- a/examples/single-account-aws-role/main.tf
+++ b/examples/single-account-aws-role/main.tf
@@ -6,6 +6,18 @@ locals {
   enable_dspm                = true
   dspm_regions               = ["us-east-1", "us-east-2"]
   use_existing_cloudtrail    = true
+
+  # customizations
+  resource_prefix        = "cs-"
+  resource_suffix        = "-cspm"
+  custom_role_name       = "${local.resource_prefix}reader-role${local.resource_suffix}"
+  dspm_role_name         = "${local.resource_prefix}dspm-integration${local.resource_suffix}"
+  dspm_scanner_role_name = "${local.resource_prefix}dspm-scanner${local.resource_suffix}"
+  eventbridge_role_name  = "${local.resource_prefix}eventbridge-role${local.resource_suffix}"
+  tags = {
+    DeployedBy = var.me
+    Product    = "FalconCloudSecurity"
+  }
 }
 
 provider "crowdstrike" {
@@ -18,7 +30,8 @@ resource "crowdstrike_cloud_aws_account" "this" {
   account_id = var.account_id
 
   asset_inventory = {
-    enabled = true
+    enabled   = true
+    role_name = local.custom_role_name
   }
 
   realtime_visibility = {
@@ -36,7 +49,8 @@ resource "crowdstrike_cloud_aws_account" "this" {
   }
 
   dspm = {
-    enabled = local.enable_dspm
+    enabled   = local.enable_dspm
+    role_name = local.dspm_role_name
   }
   provider = crowdstrike
 }
@@ -56,12 +70,18 @@ module "fcs_account" {
   enable_dspm                 = local.enable_dspm
   dspm_regions                = local.dspm_regions
 
-  account_type           = crowdstrike_cloud_aws_account.this.account_type
   iam_role_name          = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id            = crowdstrike_cloud_aws_account.this.external_id
   intermediate_role_arn  = crowdstrike_cloud_aws_account.this.intermediate_role_arn
   eventbus_arn           = crowdstrike_cloud_aws_account.this.eventbus_arn
+  eventbridge_role_name  = local.eventbridge_role_name
+  dspm_role_name         = crowdstrike_cloud_aws_account.this.dspm_role_name
   cloudtrail_bucket_name = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
+  dspm_scanner_role_name = local.dspm_scanner_role_name
+
+  resource_prefix = local.resource_prefix
+  resource_suffix = local.resource_suffix
+  tags            = local.tags
 
   providers = {
     crowdstrike = crowdstrike

--- a/examples/single-account-aws-role/variables.tf
+++ b/examples/single-account-aws-role/variables.tf
@@ -24,3 +24,9 @@ variable "aws_role_name" {
   type        = string
   description = "The AWS role name used for assuming into this account"
 }
+
+variable "me" {
+  type        = string
+  default     = "unspecified"
+  description = "The user running terraform"
+}

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -74,19 +74,19 @@ resource "crowdstrike_cloud_aws_account" "this" {
 }
 
 module "fcs_account_onboarding" {
-  source                      = "../../"
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  account_id                  = var.account_id
-  primary_region              = local.primary_region
-  enable_sensor_management    = local.enable_sensor_management
-  enable_realtime_visibility  = local.enable_realtime_visibility
-  realtime_visibility_regions = local.realtime_visibility_regions
-  enable_idp                  = local.enable_idp
-  use_existing_cloudtrail     = local.use_existing_cloudtrail
-  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-east-1")
-  dspm_regions                = local.dspm_regions
-  dspm_scanner_role_name      = local.dspm_scanner_role_name
+  source                     = "../../"
+  falcon_client_id           = var.falcon_client_id
+  falcon_client_secret       = var.falcon_client_secret
+  account_id                 = var.account_id
+  primary_region             = local.primary_region
+  enable_sensor_management   = local.enable_sensor_management
+  enable_realtime_visibility = local.enable_realtime_visibility
+  create_rtvd_rules          = contains(local.realtime_visibility_regions, "all") || contains(local.realtime_visibility_regions, "us-east-1")
+  enable_idp                 = local.enable_idp
+  use_existing_cloudtrail    = local.use_existing_cloudtrail
+  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-east-1")
+  dspm_regions               = local.dspm_regions
+  dspm_scanner_role_name     = local.dspm_scanner_role_name
 
   iam_role_name          = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id            = crowdstrike_cloud_aws_account.this.external_id
@@ -107,19 +107,19 @@ module "fcs_account_onboarding" {
 }
 
 module "fcs_account_us_east_2" {
-  source                      = "../.."
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  account_id                  = var.account_id
-  primary_region              = local.primary_region
-  enable_sensor_management    = local.enable_sensor_management
-  enable_realtime_visibility  = local.enable_realtime_visibility
-  realtime_visibility_regions = local.realtime_visibility_regions
-  enable_idp                  = local.enable_idp
-  use_existing_cloudtrail     = local.use_existing_cloudtrail
-  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-east-2")
-  dspm_regions                = local.dspm_regions
-  dspm_scanner_role_name      = local.dspm_scanner_role_name
+  source                     = "../.."
+  falcon_client_id           = var.falcon_client_id
+  falcon_client_secret       = var.falcon_client_secret
+  account_id                 = var.account_id
+  primary_region             = local.primary_region
+  enable_sensor_management   = local.enable_sensor_management
+  enable_realtime_visibility = local.enable_realtime_visibility
+  create_rtvd_rules          = contains(local.realtime_visibility_regions, "all") || contains(local.realtime_visibility_regions, "us-east-2")
+  enable_idp                 = local.enable_idp
+  use_existing_cloudtrail    = local.use_existing_cloudtrail
+  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-east-2")
+  dspm_regions               = local.dspm_regions
+  dspm_scanner_role_name     = local.dspm_scanner_role_name
 
   iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id                     = crowdstrike_cloud_aws_account.this.external_id
@@ -142,19 +142,19 @@ module "fcs_account_us_east_2" {
 }
 
 module "fcs_account_us_west_1" {
-  source                      = "../.."
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  account_id                  = var.account_id
-  primary_region              = local.primary_region
-  enable_sensor_management    = local.enable_sensor_management
-  enable_realtime_visibility  = local.enable_realtime_visibility
-  realtime_visibility_regions = local.realtime_visibility_regions
-  enable_idp                  = local.enable_idp
-  use_existing_cloudtrail     = local.use_existing_cloudtrail
-  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-west-1")
-  dspm_regions                = local.dspm_regions
-  dspm_scanner_role_name      = local.dspm_scanner_role_name
+  source                     = "../.."
+  falcon_client_id           = var.falcon_client_id
+  falcon_client_secret       = var.falcon_client_secret
+  account_id                 = var.account_id
+  primary_region             = local.primary_region
+  enable_sensor_management   = local.enable_sensor_management
+  enable_realtime_visibility = local.enable_realtime_visibility
+  create_rtvd_rules          = contains(local.realtime_visibility_regions, "all") || contains(local.realtime_visibility_regions, "us-west-1")
+  enable_idp                 = local.enable_idp
+  use_existing_cloudtrail    = local.use_existing_cloudtrail
+  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-west-1")
+  dspm_regions               = local.dspm_regions
+  dspm_scanner_role_name     = local.dspm_scanner_role_name
 
   iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id                     = crowdstrike_cloud_aws_account.this.external_id
@@ -177,19 +177,19 @@ module "fcs_account_us_west_1" {
 }
 
 module "fcs_account_us_west_2" {
-  source                      = "../.."
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  account_id                  = var.account_id
-  primary_region              = local.primary_region
-  enable_sensor_management    = local.enable_sensor_management
-  enable_realtime_visibility  = local.enable_realtime_visibility
-  realtime_visibility_regions = local.realtime_visibility_regions
-  enable_idp                  = local.enable_idp
-  use_existing_cloudtrail     = local.use_existing_cloudtrail
-  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-west-2")
-  dspm_regions                = local.dspm_regions
-  dspm_scanner_role_name      = local.dspm_scanner_role_name
+  source                     = "../.."
+  falcon_client_id           = var.falcon_client_id
+  falcon_client_secret       = var.falcon_client_secret
+  account_id                 = var.account_id
+  primary_region             = local.primary_region
+  enable_sensor_management   = local.enable_sensor_management
+  enable_realtime_visibility = local.enable_realtime_visibility
+  create_rtvd_rules          = contains(local.realtime_visibility_regions, "all") || contains(local.realtime_visibility_regions, "us-west-2")
+  enable_idp                 = local.enable_idp
+  use_existing_cloudtrail    = local.use_existing_cloudtrail
+  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-west-2")
+  dspm_regions               = local.dspm_regions
+  dspm_scanner_role_name     = local.dspm_scanner_role_name
 
   iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id                     = crowdstrike_cloud_aws_account.this.external_id

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -20,13 +20,14 @@ provider "aws" {
 }
 
 locals {
-  enable_realtime_visibility = true
-  primary_region             = "us-east-1"
-  enable_idp                 = true
-  enable_sensor_management   = true
-  enable_dspm                = true
-  dspm_regions               = ["us-east-1", "us-east-2"]
-  use_existing_cloudtrail    = true
+  enable_realtime_visibility  = true
+  realtime_visibility_regions = ["all"]
+  primary_region              = "us-east-1"
+  enable_idp                  = true
+  enable_sensor_management    = true
+  enable_dspm                 = true
+  dspm_regions                = ["us-east-1", "us-east-2"]
+  use_existing_cloudtrail     = true
 
   # customizations
   resource_prefix        = "cs-"
@@ -34,6 +35,7 @@ locals {
   custom_role_name       = "${local.resource_prefix}reader-role${local.resource_suffix}"
   dspm_role_name         = "${local.resource_prefix}dspm-integration${local.resource_suffix}"
   dspm_scanner_role_name = "${local.resource_prefix}dspm-scanner${local.resource_suffix}"
+  eventbridge_role_name  = "${local.resource_prefix}eventbridge-role${local.resource_suffix}"
 
   tags = {
     DeployedBy = var.me
@@ -72,30 +74,31 @@ resource "crowdstrike_cloud_aws_account" "this" {
 }
 
 module "fcs_account_onboarding" {
-  source                     = "../../"
-  falcon_client_id           = var.falcon_client_id
-  falcon_client_secret       = var.falcon_client_secret
-  account_id                 = var.account_id
-  primary_region             = local.primary_region
-  enable_sensor_management   = local.enable_sensor_management
-  enable_realtime_visibility = local.enable_realtime_visibility
-  enable_idp                 = local.enable_idp
-  use_existing_cloudtrail    = local.use_existing_cloudtrail
-  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-east-1")
-  dspm_regions               = local.dspm_regions
-  dspm_scanner_role_name     = local.dspm_scanner_role_name
+  source                      = "../../"
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  account_id                  = var.account_id
+  primary_region              = local.primary_region
+  enable_sensor_management    = local.enable_sensor_management
+  enable_realtime_visibility  = local.enable_realtime_visibility
+  realtime_visibility_regions = local.realtime_visibility_regions
+  enable_idp                  = local.enable_idp
+  use_existing_cloudtrail     = local.use_existing_cloudtrail
+  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-east-1")
+  dspm_regions                = local.dspm_regions
+  dspm_scanner_role_name      = local.dspm_scanner_role_name
 
   iam_role_name          = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id            = crowdstrike_cloud_aws_account.this.external_id
   intermediate_role_arn  = crowdstrike_cloud_aws_account.this.intermediate_role_arn
   eventbus_arn           = crowdstrike_cloud_aws_account.this.eventbus_arn
+  eventbridge_role_name  = local.eventbridge_role_name
   dspm_role_name         = crowdstrike_cloud_aws_account.this.dspm_role_name
   cloudtrail_bucket_name = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
 
-  resource_prefix       = local.resource_prefix
-  resource_suffix       = local.resource_suffix
-  eventbridge_role_name = "${local.resource_prefix}cspm-eventbridge${local.resource_suffix}"
-  tags                  = local.tags
+  resource_prefix = local.resource_prefix
+  resource_suffix = local.resource_suffix
+  tags            = local.tags
 
   providers = {
     aws         = aws.us-east-1
@@ -104,32 +107,33 @@ module "fcs_account_onboarding" {
 }
 
 module "fcs_account_us_east_2" {
-  source                     = "../.."
-  falcon_client_id           = var.falcon_client_id
-  falcon_client_secret       = var.falcon_client_secret
-  account_id                 = var.account_id
-  primary_region             = local.primary_region
-  enable_sensor_management   = local.enable_sensor_management
-  enable_realtime_visibility = local.enable_realtime_visibility
-  enable_idp                 = local.enable_idp
-  use_existing_cloudtrail    = local.use_existing_cloudtrail
-  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-east-2")
-  dspm_regions               = local.dspm_regions
-  dspm_scanner_role_name     = local.dspm_scanner_role_name
+  source                      = "../.."
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  account_id                  = var.account_id
+  primary_region              = local.primary_region
+  enable_sensor_management    = local.enable_sensor_management
+  enable_realtime_visibility  = local.enable_realtime_visibility
+  realtime_visibility_regions = local.realtime_visibility_regions
+  enable_idp                  = local.enable_idp
+  use_existing_cloudtrail     = local.use_existing_cloudtrail
+  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-east-2")
+  dspm_regions                = local.dspm_regions
+  dspm_scanner_role_name      = local.dspm_scanner_role_name
 
   iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id                     = crowdstrike_cloud_aws_account.this.external_id
   intermediate_role_arn           = crowdstrike_cloud_aws_account.this.intermediate_role_arn
   eventbus_arn                    = crowdstrike_cloud_aws_account.this.eventbus_arn
+  eventbridge_role_name           = local.eventbridge_role_name
   dspm_role_name                  = crowdstrike_cloud_aws_account.this.dspm_role_name
   cloudtrail_bucket_name          = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
   dspm_integration_role_unique_id = module.fcs_account_onboarding.integration_role_unique_id
   dspm_scanner_role_unique_id     = module.fcs_account_onboarding.scanner_role_unique_id
 
-  resource_prefix       = local.resource_prefix
-  resource_suffix       = local.resource_suffix
-  eventbridge_role_name = "${local.resource_prefix}cspm-eventbridge${local.resource_suffix}"
-  tags                  = local.tags
+  resource_prefix = local.resource_prefix
+  resource_suffix = local.resource_suffix
+  tags            = local.tags
 
   providers = {
     aws         = aws.us-east-2
@@ -138,32 +142,33 @@ module "fcs_account_us_east_2" {
 }
 
 module "fcs_account_us_west_1" {
-  source                     = "../.."
-  falcon_client_id           = var.falcon_client_id
-  falcon_client_secret       = var.falcon_client_secret
-  account_id                 = var.account_id
-  primary_region             = local.primary_region
-  enable_sensor_management   = local.enable_sensor_management
-  enable_realtime_visibility = local.enable_realtime_visibility
-  enable_idp                 = local.enable_idp
-  use_existing_cloudtrail    = local.use_existing_cloudtrail
-  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-west-1")
-  dspm_regions               = local.dspm_regions
-  dspm_scanner_role_name     = local.dspm_scanner_role_name
+  source                      = "../.."
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  account_id                  = var.account_id
+  primary_region              = local.primary_region
+  enable_sensor_management    = local.enable_sensor_management
+  enable_realtime_visibility  = local.enable_realtime_visibility
+  realtime_visibility_regions = local.realtime_visibility_regions
+  enable_idp                  = local.enable_idp
+  use_existing_cloudtrail     = local.use_existing_cloudtrail
+  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-west-1")
+  dspm_regions                = local.dspm_regions
+  dspm_scanner_role_name      = local.dspm_scanner_role_name
 
   iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id                     = crowdstrike_cloud_aws_account.this.external_id
   intermediate_role_arn           = crowdstrike_cloud_aws_account.this.intermediate_role_arn
   eventbus_arn                    = crowdstrike_cloud_aws_account.this.eventbus_arn
+  eventbridge_role_name           = local.eventbridge_role_name
   dspm_role_name                  = crowdstrike_cloud_aws_account.this.dspm_role_name
   cloudtrail_bucket_name          = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
   dspm_integration_role_unique_id = module.fcs_account_onboarding.integration_role_unique_id
   dspm_scanner_role_unique_id     = module.fcs_account_onboarding.scanner_role_unique_id
 
-  resource_prefix       = local.resource_prefix
-  resource_suffix       = local.resource_suffix
-  eventbridge_role_name = "${local.resource_prefix}cspm-eventbridge${local.resource_suffix}"
-  tags                  = local.tags
+  resource_prefix = local.resource_prefix
+  resource_suffix = local.resource_suffix
+  tags            = local.tags
 
   providers = {
     aws         = aws.us-west-1
@@ -172,32 +177,33 @@ module "fcs_account_us_west_1" {
 }
 
 module "fcs_account_us_west_2" {
-  source                     = "../.."
-  falcon_client_id           = var.falcon_client_id
-  falcon_client_secret       = var.falcon_client_secret
-  account_id                 = var.account_id
-  primary_region             = local.primary_region
-  enable_sensor_management   = local.enable_sensor_management
-  enable_realtime_visibility = local.enable_realtime_visibility
-  enable_idp                 = local.enable_idp
-  use_existing_cloudtrail    = local.use_existing_cloudtrail
-  enable_dspm                = local.enable_dspm && contains(local.dspm_regions, "us-west-2")
-  dspm_regions               = local.dspm_regions
-  dspm_scanner_role_name     = local.dspm_scanner_role_name
+  source                      = "../.."
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  account_id                  = var.account_id
+  primary_region              = local.primary_region
+  enable_sensor_management    = local.enable_sensor_management
+  enable_realtime_visibility  = local.enable_realtime_visibility
+  realtime_visibility_regions = local.realtime_visibility_regions
+  enable_idp                  = local.enable_idp
+  use_existing_cloudtrail     = local.use_existing_cloudtrail
+  enable_dspm                 = local.enable_dspm && contains(local.dspm_regions, "us-west-2")
+  dspm_regions                = local.dspm_regions
+  dspm_scanner_role_name      = local.dspm_scanner_role_name
 
   iam_role_name                   = crowdstrike_cloud_aws_account.this.iam_role_name
   external_id                     = crowdstrike_cloud_aws_account.this.external_id
   intermediate_role_arn           = crowdstrike_cloud_aws_account.this.intermediate_role_arn
   eventbus_arn                    = crowdstrike_cloud_aws_account.this.eventbus_arn
+  eventbridge_role_name           = local.eventbridge_role_name
   dspm_role_name                  = crowdstrike_cloud_aws_account.this.dspm_role_name
   cloudtrail_bucket_name          = crowdstrike_cloud_aws_account.this.cloudtrail_bucket_name
   dspm_integration_role_unique_id = module.fcs_account_onboarding.integration_role_unique_id
   dspm_scanner_role_unique_id     = module.fcs_account_onboarding.scanner_role_unique_id
 
-  resource_prefix       = local.resource_prefix
-  resource_suffix       = local.resource_suffix
-  eventbridge_role_name = "${local.resource_prefix}cspm-eventbridge${local.resource_suffix}"
-  tags                  = local.tags
+  resource_prefix = local.resource_prefix
+  resource_suffix = local.resource_suffix
+  tags            = local.tags
 
   providers = {
     aws         = aws.us-west-2

--- a/main.tf
+++ b/main.tf
@@ -67,22 +67,22 @@ module "sensor_management" {
 }
 
 module "realtime_visibility" {
-  count                       = (var.enable_realtime_visibility || var.enable_idp) ? 1 : 0
-  source                      = "./modules/realtime-visibility/"
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbridge_role_name       = var.eventbridge_role_name
-  eventbus_arn                = local.eventbus_arn
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = var.is_gov && var.account_type == "commercial"
-  is_primary_region           = local.is_primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  primary_region              = var.primary_region
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  count                   = (var.enable_realtime_visibility || var.enable_idp) ? 1 : 0
+  source                  = "./modules/realtime-visibility/"
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbridge_role_name   = var.eventbridge_role_name
+  eventbus_arn            = local.eventbus_arn
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = var.is_gov && var.account_type == "commercial"
+  is_primary_region       = local.is_primary_region
+  create_rules            = var.create_rtvd_rules
+  primary_region          = var.primary_region
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,

--- a/main.tf
+++ b/main.tf
@@ -67,21 +67,22 @@ module "sensor_management" {
 }
 
 module "realtime_visibility" {
-  count                   = (var.enable_realtime_visibility || var.enable_idp) ? 1 : 0
-  source                  = "./modules/realtime-visibility/"
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbridge_role_name   = var.eventbridge_role_name
-  eventbus_arn            = local.eventbus_arn
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = var.is_gov && var.account_type == "commercial"
-  is_primary_region       = local.is_primary_region
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  count                       = (var.enable_realtime_visibility || var.enable_idp) ? 1 : 0
+  source                      = "./modules/realtime-visibility/"
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbridge_role_name       = var.eventbridge_role_name
+  eventbus_arn                = local.eventbus_arn
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = var.is_gov && var.account_type == "commercial"
+  is_primary_region           = local.is_primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  primary_region              = var.primary_region
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,

--- a/modules/aws-profile/README.md
+++ b/modules/aws-profile/README.md
@@ -10,7 +10,7 @@ This Terraform module allows onboarding multiple aws regions within the same mod
 The module achieves multi-region deployment by defining provider blocks internally. These `aws` provider blocks will use the provided `aws_prfoile` to authenticate. This design choice does create certain limitations to be aware of; for example, the module is not compatible with Terraform's `for_each`, `count`, and `depends_on` arguments. Your workflow for destroying resources defined in this module will be also be impacted see [Running Terraform Destroy](#Running-Terraform-Destroy). You can learn more about the implications by reading [terraform's documentation](https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations).
 
 > [!IMPORTANT]
-> It is recommeded to use the root module `CrowdStrik/cloud-registration/aws` over this wrapper module.
+> It is recommeded to use the root module `CrowdStrike/cloud-registration/aws` over this wrapper module.
 
 ## Running Terraform Destroy
 
@@ -195,13 +195,11 @@ module "fcs_child_account_1" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.45 |
 | <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.19 |
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_regions.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [crowdstrike_cloud_aws_account.target](https://registry.terraform.io/providers/CrowdStrike/crowdstrike/latest/docs/data-sources/cloud_aws_account) | data source |
 ## Inputs
 
@@ -229,7 +227,7 @@ module "fcs_child_account_1" {
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The AWS Organization ID. Leave blank when onboarding single account | `string` | `""` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The name of the policy used to set the permissions boundary for IAM roles | `string` | `""` | no |
 | <a name="input_primary_region"></a> [primary\_region](#input\_primary\_region) | Region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. Distinct from dspm\_regions which controls region-specific resource deployment. | `string` | n/a | yes |
-| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions to onboard Realtime Visibility monitoring. Use ["all"] to onboard all available regions | `list(string)` | `[]` | no |
+| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions where Real-time visibility and detection should be enabled. Use ["all"] to onboard all regions | `list(string)` | <pre>[<br/>  "all"<br/>]</pre> | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix to be added to all resource names | `string` | `"CrowdStrike-"` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to be added to all resource names | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources that support tagging | `map(string)` | `{}` | no |

--- a/modules/aws-profile/README.md
+++ b/modules/aws-profile/README.md
@@ -195,11 +195,13 @@ module "fcs_child_account_1" {
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.45 |
 | <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.19 |
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_regions.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [crowdstrike_cloud_aws_account.target](https://registry.terraform.io/providers/CrowdStrike/crowdstrike/latest/docs/data-sources/cloud_aws_account) | data source |
 ## Inputs
 

--- a/modules/aws-profile/realtime_visibility.tf
+++ b/modules/aws-profile/realtime_visibility.tf
@@ -7,23 +7,23 @@ data "aws_regions" "available" {
 }
 
 module "rtvd_us_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -35,23 +35,23 @@ module "rtvd_us_east_1" {
 }
 
 module "rtvd_us_east_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-east-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-east-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-east-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -63,23 +63,23 @@ module "rtvd_us_east_2" {
 }
 
 module "rtvd_us_west_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-west-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-west-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-west-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -91,23 +91,23 @@ module "rtvd_us_west_1" {
 }
 
 module "rtvd_us_west_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-west-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-west-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-west-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -119,23 +119,23 @@ module "rtvd_us_west_2" {
 }
 
 module "rtvd_af_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "af-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "af-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "af-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "af-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "af-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -147,23 +147,23 @@ module "rtvd_af_south_1" {
 }
 
 module "rtvd_ap_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -175,23 +175,23 @@ module "rtvd_ap_east_1" {
 }
 
 module "rtvd_ap_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -203,23 +203,23 @@ module "rtvd_ap_south_1" {
 }
 
 module "rtvd_ap_south_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-south-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-south-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-south-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -231,23 +231,23 @@ module "rtvd_ap_south_2" {
 }
 
 module "rtvd_ap_southeast_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -259,23 +259,23 @@ module "rtvd_ap_southeast_1" {
 }
 
 module "rtvd_ap_southeast_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -287,23 +287,23 @@ module "rtvd_ap_southeast_2" {
 }
 
 module "rtvd_ap_southeast_3" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-3") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-3"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  permissions_boundary        = var.permissions_boundary
-  falcon_client_secret        = var.falcon_client_secret
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-3") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-3"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-3")
+  falcon_client_id        = var.falcon_client_id
+  permissions_boundary    = var.permissions_boundary
+  falcon_client_secret    = var.falcon_client_secret
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -315,23 +315,23 @@ module "rtvd_ap_southeast_3" {
 }
 
 module "rtvd_ap_southeast_4" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-4") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-4"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-4") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-4"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-4")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -343,23 +343,23 @@ module "rtvd_ap_southeast_4" {
 }
 
 module "rtvd_ap_northeast_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-northeast-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-northeast-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-northeast-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -371,23 +371,23 @@ module "rtvd_ap_northeast_1" {
 }
 
 module "rtvd_ap_northeast_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-northeast-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-northeast-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-northeast-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -399,23 +399,23 @@ module "rtvd_ap_northeast_2" {
 }
 
 module "rtvd_ap_northeast_3" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-3") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-northeast-3"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-3") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-northeast-3"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-northeast-3")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -427,23 +427,23 @@ module "rtvd_ap_northeast_3" {
 }
 
 module "rtvd_ca_central_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ca-central-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ca-central-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ca-central-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ca-central-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ca-central-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -455,23 +455,23 @@ module "rtvd_ca_central_1" {
 }
 
 module "rtvd_eu_central_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-central-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-central-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-central-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -483,23 +483,23 @@ module "rtvd_eu_central_1" {
 }
 
 module "rtvd_eu_west_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-west-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-west-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-west-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -511,23 +511,23 @@ module "rtvd_eu_west_1" {
 }
 
 module "rtvd_eu_west_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-west-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-west-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-west-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -539,23 +539,23 @@ module "rtvd_eu_west_2" {
 }
 
 module "rtvd_eu_west_3" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-3") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-west-3"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-3") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-west-3"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-west-3")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -567,23 +567,23 @@ module "rtvd_eu_west_3" {
 }
 
 module "rtvd_eu_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -595,23 +595,23 @@ module "rtvd_eu_south_1" {
 }
 
 module "rtvd_eu_south_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-south-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-south-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-south-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -623,23 +623,23 @@ module "rtvd_eu_south_2" {
 }
 
 module "rtvd_eu_north_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-north-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-north-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-north-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-north-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-north-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -651,23 +651,23 @@ module "rtvd_eu_north_1" {
 }
 
 module "rtvd_eu_central_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-central-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-central-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-central-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -679,23 +679,23 @@ module "rtvd_eu_central_2" {
 }
 
 module "rtvd_me_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "me-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "me-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "me-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -707,23 +707,23 @@ module "rtvd_me_south_1" {
 }
 
 module "rtvd_me_central_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-central-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "me-central-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-central-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "me-central-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "me-central-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -735,23 +735,23 @@ module "rtvd_me_central_1" {
 }
 
 module "rtvd_sa_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "sa-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "sa-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "sa-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "sa-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "sa-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -763,23 +763,23 @@ module "rtvd_sa_east_1" {
 }
 
 module "rtvd_us_gov_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-gov-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-gov-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-gov-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -791,23 +791,23 @@ module "rtvd_us_gov_east_1" {
 }
 
 module "rtvd_us_gov_west_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-west-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-gov-west-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-west-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-gov-west-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-gov-west-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,

--- a/modules/aws-profile/realtime_visibility.tf
+++ b/modules/aws-profile/realtime_visibility.tf
@@ -6,54 +6,52 @@ data "aws_regions" "available" {
   }
 }
 
-locals {
-  target_regions = contains(var.realtime_visibility_regions, "all") ? data.aws_regions.available.names : var.realtime_visibility_regions
-}
-
 module "rtvd_us_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
   ]
 
   providers = {
-    aws = aws
+    aws = aws.us-east-1
   }
 }
 
 module "rtvd_us_east_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-east-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-east-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-east-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -65,22 +63,23 @@ module "rtvd_us_east_2" {
 }
 
 module "rtvd_us_west_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-west-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-west-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-west-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -92,22 +91,23 @@ module "rtvd_us_west_1" {
 }
 
 module "rtvd_us_west_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-west-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-west-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-west-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -119,22 +119,23 @@ module "rtvd_us_west_2" {
 }
 
 module "rtvd_af_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "af-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "af-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "af-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "af-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -146,22 +147,23 @@ module "rtvd_af_south_1" {
 }
 
 module "rtvd_ap_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -173,22 +175,23 @@ module "rtvd_ap_east_1" {
 }
 
 module "rtvd_ap_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -200,22 +203,23 @@ module "rtvd_ap_south_1" {
 }
 
 module "rtvd_ap_south_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-south-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-south-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-south-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -227,22 +231,23 @@ module "rtvd_ap_south_2" {
 }
 
 module "rtvd_ap_southeast_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -254,22 +259,23 @@ module "rtvd_ap_southeast_1" {
 }
 
 module "rtvd_ap_southeast_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -281,22 +287,23 @@ module "rtvd_ap_southeast_2" {
 }
 
 module "rtvd_ap_southeast_3" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-3") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-3"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  permissions_boundary    = var.permissions_boundary
-  falcon_client_secret    = var.falcon_client_secret
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-3") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-3"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  permissions_boundary        = var.permissions_boundary
+  falcon_client_secret        = var.falcon_client_secret
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -308,22 +315,23 @@ module "rtvd_ap_southeast_3" {
 }
 
 module "rtvd_ap_southeast_4" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-4") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-4"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-4") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-4"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -335,22 +343,23 @@ module "rtvd_ap_southeast_4" {
 }
 
 module "rtvd_ap_northeast_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-northeast-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-northeast-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-northeast-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -362,22 +371,23 @@ module "rtvd_ap_northeast_1" {
 }
 
 module "rtvd_ap_northeast_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-northeast-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-northeast-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-northeast-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -389,22 +399,23 @@ module "rtvd_ap_northeast_2" {
 }
 
 module "rtvd_ap_northeast_3" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-northeast-3") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-northeast-3"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-3") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-northeast-3"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -416,22 +427,23 @@ module "rtvd_ap_northeast_3" {
 }
 
 module "rtvd_ca_central_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ca-central-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ca-central-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ca-central-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ca-central-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -443,22 +455,23 @@ module "rtvd_ca_central_1" {
 }
 
 module "rtvd_eu_central_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-central-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-central-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-central-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -470,22 +483,23 @@ module "rtvd_eu_central_1" {
 }
 
 module "rtvd_eu_west_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-west-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-west-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-west-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -497,22 +511,23 @@ module "rtvd_eu_west_1" {
 }
 
 module "rtvd_eu_west_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-west-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-west-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-west-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -524,22 +539,23 @@ module "rtvd_eu_west_2" {
 }
 
 module "rtvd_eu_west_3" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-west-3") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-west-3"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-3") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-west-3"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -551,22 +567,23 @@ module "rtvd_eu_west_3" {
 }
 
 module "rtvd_eu_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -578,22 +595,23 @@ module "rtvd_eu_south_1" {
 }
 
 module "rtvd_eu_south_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-south-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-south-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-south-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -605,22 +623,23 @@ module "rtvd_eu_south_2" {
 }
 
 module "rtvd_eu_north_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-north-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-north-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-north-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-north-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -632,22 +651,23 @@ module "rtvd_eu_north_1" {
 }
 
 module "rtvd_eu_central_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-central-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-central-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-central-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -659,22 +679,23 @@ module "rtvd_eu_central_2" {
 }
 
 module "rtvd_me_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "me-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "me-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "me-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -686,22 +707,23 @@ module "rtvd_me_south_1" {
 }
 
 module "rtvd_me_central_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "me-central-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "me-central-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-central-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "me-central-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -713,22 +735,23 @@ module "rtvd_me_central_1" {
 }
 
 module "rtvd_sa_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "sa-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "sa-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "sa-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "sa-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -740,22 +763,23 @@ module "rtvd_sa_east_1" {
 }
 
 module "rtvd_us_gov_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-gov-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-gov-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-gov-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -767,22 +791,23 @@ module "rtvd_us_gov_east_1" {
 }
 
 module "rtvd_us_gov_west_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-gov-west-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-gov-west-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-west-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-gov-west-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,

--- a/modules/aws-profile/variables.tf
+++ b/modules/aws-profile/variables.tf
@@ -77,8 +77,8 @@ variable "use_existing_cloudtrail" {
 
 variable "realtime_visibility_regions" {
   type        = list(string)
-  default     = []
-  description = "The list of regions to onboard Realtime Visibility monitoring. Use [\"all\"] to onboard all available regions"
+  default     = ["all"]
+  description = "The list of regions where Real-time visibility and detection should be enabled. Use [\"all\"] to onboard all regions"
 }
 
 variable "enable_idp" {

--- a/modules/aws-role/README.md
+++ b/modules/aws-role/README.md
@@ -10,7 +10,7 @@ This Terraform module allows onboarding multiple aws regions within the same mod
 The module achieves multi-region deployment by defining provider blocks internally. These `aws` provider blocks will use the provided `aws_role` to authenticate. This design choice does create certain limitations to be aware of; for example, the module is not compatible with Terraform's `for_each`, `count`, and `depends_on` arguments. Your workflow for destroying resources defined in this module will be also be impacted see [Running Terraform Destroy](#Running-Terraform-Destroy). You can learn more about the implications by reading [terraform's documentation](https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations).
 
 > [!IMPORTANT]
-> It is recommeded to use the root module `CrowdStrik/cloud-registration/aws` over this wrapper module.
+> It is recommeded to use the root module `CrowdStrike/cloud-registration/aws` over this wrapper module.
 
 ## Running Terraform Destroy
 
@@ -189,11 +189,13 @@ module "fcs_child_account_1" {
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.45 |
 | <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.19 |
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_regions.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [crowdstrike_cloud_aws_account.target](https://registry.terraform.io/providers/CrowdStrike/crowdstrike/latest/docs/data-sources/cloud_aws_account) | data source |
 ## Inputs
 

--- a/modules/aws-role/README.md
+++ b/modules/aws-role/README.md
@@ -10,7 +10,7 @@ This Terraform module allows onboarding multiple aws regions within the same mod
 The module achieves multi-region deployment by defining provider blocks internally. These `aws` provider blocks will use the provided `aws_role` to authenticate. This design choice does create certain limitations to be aware of; for example, the module is not compatible with Terraform's `for_each`, `count`, and `depends_on` arguments. Your workflow for destroying resources defined in this module will be also be impacted see [Running Terraform Destroy](#Running-Terraform-Destroy). You can learn more about the implications by reading [terraform's documentation](https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations).
 
 > [!IMPORTANT]
-> It is recommeded to use the root module `CrowdStrike/cloud-registration/aws` over this wrapper module.
+> It is recommeded to use the root module `CrowdStrik/cloud-registration/aws` over this wrapper module.
 
 ## Running Terraform Destroy
 
@@ -189,13 +189,11 @@ module "fcs_child_account_1" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.45 |
 | <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.19 |
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_regions.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [crowdstrike_cloud_aws_account.target](https://registry.terraform.io/providers/CrowdStrike/crowdstrike/latest/docs/data-sources/cloud_aws_account) | data source |
 ## Inputs
 
@@ -223,7 +221,7 @@ module "fcs_child_account_1" {
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The AWS Organization ID. Leave blank when onboarding single account | `string` | `""` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The name of the policy used to set the permissions boundary for IAM roles | `string` | `""` | no |
 | <a name="input_primary_region"></a> [primary\_region](#input\_primary\_region) | Region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. Distinct from dspm\_regions which controls region-specific resource deployment. | `string` | n/a | yes |
-| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions to onboard Realtime Visibility monitoring. Use ["all"] to onboard all available regions | `list(string)` | `[]` | no |
+| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions where Real-time visibility and detection should be enabled. Use ["all"] to onboard all regions | `list(string)` | <pre>[<br/>  "all"<br/>]</pre> | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix to be added to all resource names | `string` | `"CrowdStrike-"` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to be added to all resource names | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources that support tagging | `map(string)` | `{}` | no |

--- a/modules/aws-role/docs/.header.md
+++ b/modules/aws-role/docs/.header.md
@@ -10,7 +10,7 @@ The module achieves multi-region deployment by defining provider blocks internal
 
 
 > [!IMPORTANT]
-> It is recommeded to use the root module `CrowdStrik/cloud-registration/aws` over this wrapper module.
+> It is recommeded to use the root module `CrowdStrike/cloud-registration/aws` over this wrapper module.
 
 ## Running Terraform Destroy
 

--- a/modules/aws-role/realtime_visibility.tf
+++ b/modules/aws-role/realtime_visibility.tf
@@ -7,23 +7,23 @@ data "aws_regions" "available" {
 }
 
 module "rtvd_us_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -35,23 +35,23 @@ module "rtvd_us_east_1" {
 }
 
 module "rtvd_us_east_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-east-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-east-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-east-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -63,23 +63,23 @@ module "rtvd_us_east_2" {
 }
 
 module "rtvd_us_west_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-west-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-west-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-west-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -91,23 +91,23 @@ module "rtvd_us_west_1" {
 }
 
 module "rtvd_us_west_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-west-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-west-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-west-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -119,23 +119,23 @@ module "rtvd_us_west_2" {
 }
 
 module "rtvd_af_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "af-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "af-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "af-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "af-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "af-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -147,23 +147,23 @@ module "rtvd_af_south_1" {
 }
 
 module "rtvd_ap_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -175,23 +175,23 @@ module "rtvd_ap_east_1" {
 }
 
 module "rtvd_ap_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -203,23 +203,23 @@ module "rtvd_ap_south_1" {
 }
 
 module "rtvd_ap_south_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-south-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-south-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-south-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -231,23 +231,23 @@ module "rtvd_ap_south_2" {
 }
 
 module "rtvd_ap_southeast_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -259,23 +259,23 @@ module "rtvd_ap_southeast_1" {
 }
 
 module "rtvd_ap_southeast_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -287,23 +287,23 @@ module "rtvd_ap_southeast_2" {
 }
 
 module "rtvd_ap_southeast_3" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-3") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-3"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-3") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-3"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-3")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -315,23 +315,23 @@ module "rtvd_ap_southeast_3" {
 }
 
 module "rtvd_ap_southeast_4" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-4") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-southeast-4"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-4") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-southeast-4"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-southeast-4")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -343,23 +343,23 @@ module "rtvd_ap_southeast_4" {
 }
 
 module "rtvd_ap_northeast_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-northeast-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-northeast-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-northeast-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -371,23 +371,23 @@ module "rtvd_ap_northeast_1" {
 }
 
 module "rtvd_ap_northeast_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-northeast-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-northeast-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-northeast-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -399,23 +399,23 @@ module "rtvd_ap_northeast_2" {
 }
 
 module "rtvd_ap_northeast_3" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-3") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ap-northeast-3"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-3") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ap-northeast-3"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ap-northeast-3")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -427,23 +427,23 @@ module "rtvd_ap_northeast_3" {
 }
 
 module "rtvd_ca_central_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ca-central-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "ca-central-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ca-central-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "ca-central-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "ca-central-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -455,23 +455,23 @@ module "rtvd_ca_central_1" {
 }
 
 module "rtvd_eu_central_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-central-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-central-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-central-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -483,23 +483,23 @@ module "rtvd_eu_central_1" {
 }
 
 module "rtvd_eu_west_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-west-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-west-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-west-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -511,23 +511,23 @@ module "rtvd_eu_west_1" {
 }
 
 module "rtvd_eu_west_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-west-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-west-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-west-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -539,23 +539,23 @@ module "rtvd_eu_west_2" {
 }
 
 module "rtvd_eu_west_3" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-3") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-west-3"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-3") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-west-3"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-west-3")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -567,23 +567,23 @@ module "rtvd_eu_west_3" {
 }
 
 module "rtvd_eu_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -595,23 +595,23 @@ module "rtvd_eu_south_1" {
 }
 
 module "rtvd_eu_south_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-south-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-south-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-south-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -623,23 +623,23 @@ module "rtvd_eu_south_2" {
 }
 
 module "rtvd_eu_north_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-north-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-north-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-north-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-north-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-north-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -651,23 +651,23 @@ module "rtvd_eu_north_1" {
 }
 
 module "rtvd_eu_central_2" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-2") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "eu-central-2"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-2") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "eu-central-2"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "eu-central-2")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -679,23 +679,23 @@ module "rtvd_eu_central_2" {
 }
 
 module "rtvd_me_south_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-south-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "me-south-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-south-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "me-south-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "me-south-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -707,23 +707,23 @@ module "rtvd_me_south_1" {
 }
 
 module "rtvd_me_central_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-central-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "me-central-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-central-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "me-central-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "me-central-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -735,23 +735,23 @@ module "rtvd_me_central_1" {
 }
 
 module "rtvd_sa_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "sa-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "sa-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "sa-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "sa-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "sa-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -763,23 +763,23 @@ module "rtvd_sa_east_1" {
 }
 
 module "rtvd_us_gov_east_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-east-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-gov-east-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-east-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-gov-east-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-gov-east-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -791,23 +791,23 @@ module "rtvd_us_gov_east_1" {
 }
 
 module "rtvd_us_gov_west_1" {
-  source                      = "../realtime-visibility/"
-  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-west-1") ? 1 : 0
-  use_existing_cloudtrail     = var.use_existing_cloudtrail
-  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
-  eventbus_arn                = local.eventbus_arn
-  eventbridge_role_name       = var.eventbridge_role_name
-  is_organization_trail       = length(var.organization_id) > 0
-  is_gov_commercial           = local.is_gov_commercial
-  is_primary_region           = var.primary_region == "us-gov-west-1"
-  primary_region              = var.primary_region
-  realtime_visibility_regions = var.realtime_visibility_regions
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  permissions_boundary        = var.permissions_boundary
-  resource_prefix             = var.resource_prefix
-  resource_suffix             = var.resource_suffix
-  tags                        = var.tags
+  source                  = "../realtime-visibility/"
+  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-west-1") ? 1 : 0
+  use_existing_cloudtrail = var.use_existing_cloudtrail
+  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
+  eventbus_arn            = local.eventbus_arn
+  eventbridge_role_name   = var.eventbridge_role_name
+  is_organization_trail   = length(var.organization_id) > 0
+  is_gov_commercial       = local.is_gov_commercial
+  is_primary_region       = var.primary_region == "us-gov-west-1"
+  primary_region          = var.primary_region
+  create_rules            = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, "us-gov-west-1")
+  falcon_client_id        = var.falcon_client_id
+  falcon_client_secret    = var.falcon_client_secret
+  permissions_boundary    = var.permissions_boundary
+  resource_prefix         = var.resource_prefix
+  resource_suffix         = var.resource_suffix
+  tags                    = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,

--- a/modules/aws-role/realtime_visibility.tf
+++ b/modules/aws-role/realtime_visibility.tf
@@ -11,49 +11,51 @@ locals {
 }
 
 module "rtvd_us_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
   ]
 
   providers = {
-    aws = aws
+    aws = aws.us-east-1
   }
 }
 
 module "rtvd_us_east_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-east-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-east-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-east-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -65,22 +67,23 @@ module "rtvd_us_east_2" {
 }
 
 module "rtvd_us_west_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-west-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-west-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-west-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -92,22 +95,23 @@ module "rtvd_us_west_1" {
 }
 
 module "rtvd_us_west_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-west-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-west-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-west-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-west-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -119,22 +123,23 @@ module "rtvd_us_west_2" {
 }
 
 module "rtvd_af_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "af-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "af-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "af-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "af-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -146,22 +151,23 @@ module "rtvd_af_south_1" {
 }
 
 module "rtvd_ap_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -173,22 +179,23 @@ module "rtvd_ap_east_1" {
 }
 
 module "rtvd_ap_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -200,22 +207,23 @@ module "rtvd_ap_south_1" {
 }
 
 module "rtvd_ap_south_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-south-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-south-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-south-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-south-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -227,22 +235,23 @@ module "rtvd_ap_south_2" {
 }
 
 module "rtvd_ap_southeast_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -254,22 +263,23 @@ module "rtvd_ap_southeast_1" {
 }
 
 module "rtvd_ap_southeast_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -281,22 +291,23 @@ module "rtvd_ap_southeast_2" {
 }
 
 module "rtvd_ap_southeast_3" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-3") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-3"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-3") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-3"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -308,22 +319,23 @@ module "rtvd_ap_southeast_3" {
 }
 
 module "rtvd_ap_southeast_4" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-southeast-4") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-southeast-4"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-southeast-4") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-southeast-4"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -335,22 +347,23 @@ module "rtvd_ap_southeast_4" {
 }
 
 module "rtvd_ap_northeast_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-northeast-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-northeast-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-northeast-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -362,22 +375,23 @@ module "rtvd_ap_northeast_1" {
 }
 
 module "rtvd_ap_northeast_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-northeast-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-northeast-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-northeast-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -389,22 +403,23 @@ module "rtvd_ap_northeast_2" {
 }
 
 module "rtvd_ap_northeast_3" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ap-northeast-3") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ap-northeast-3"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ap-northeast-3") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ap-northeast-3"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -416,22 +431,23 @@ module "rtvd_ap_northeast_3" {
 }
 
 module "rtvd_ca_central_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "ca-central-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "ca-central-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "ca-central-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "ca-central-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -443,22 +459,23 @@ module "rtvd_ca_central_1" {
 }
 
 module "rtvd_eu_central_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-central-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-central-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-central-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -470,22 +487,23 @@ module "rtvd_eu_central_1" {
 }
 
 module "rtvd_eu_west_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-west-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-west-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-west-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -497,22 +515,23 @@ module "rtvd_eu_west_1" {
 }
 
 module "rtvd_eu_west_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-west-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-west-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-west-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -524,22 +543,23 @@ module "rtvd_eu_west_2" {
 }
 
 module "rtvd_eu_west_3" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-west-3") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-west-3"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-west-3") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-west-3"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -551,22 +571,23 @@ module "rtvd_eu_west_3" {
 }
 
 module "rtvd_eu_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -578,22 +599,23 @@ module "rtvd_eu_south_1" {
 }
 
 module "rtvd_eu_south_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-south-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-south-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-south-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-south-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -605,22 +627,23 @@ module "rtvd_eu_south_2" {
 }
 
 module "rtvd_eu_north_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-north-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-north-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-north-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-north-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -632,22 +655,23 @@ module "rtvd_eu_north_1" {
 }
 
 module "rtvd_eu_central_2" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "eu-central-2") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "eu-central-2"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "eu-central-2") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "eu-central-2"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -659,22 +683,23 @@ module "rtvd_eu_central_2" {
 }
 
 module "rtvd_me_south_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "me-south-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "me-south-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-south-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "me-south-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -686,22 +711,23 @@ module "rtvd_me_south_1" {
 }
 
 module "rtvd_me_central_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "me-central-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "me-central-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "me-central-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "me-central-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -713,22 +739,23 @@ module "rtvd_me_central_1" {
 }
 
 module "rtvd_sa_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "sa-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "sa-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "sa-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "sa-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -740,22 +767,23 @@ module "rtvd_sa_east_1" {
 }
 
 module "rtvd_us_gov_east_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-gov-east-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-gov-east-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-east-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-gov-east-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,
@@ -767,22 +795,23 @@ module "rtvd_us_gov_east_1" {
 }
 
 module "rtvd_us_gov_west_1" {
-  source                  = "../realtime-visibility/"
-  count                   = (var.enable_realtime_visibility || var.enable_idp) && contains(local.target_regions, "us-gov-west-1") ? 1 : 0
-  use_existing_cloudtrail = var.use_existing_cloudtrail
-  cloudtrail_bucket_name  = local.cloudtrail_bucket_name
-  eventbus_arn            = local.eventbus_arn
-  eventbridge_role_name   = var.eventbridge_role_name
-  is_organization_trail   = length(var.organization_id) > 0
-  is_gov_commercial       = local.is_gov_commercial
-  is_primary_region       = var.primary_region == "us-gov-west-1"
-  primary_region          = var.primary_region
-  falcon_client_id        = var.falcon_client_id
-  falcon_client_secret    = var.falcon_client_secret
-  permissions_boundary    = var.permissions_boundary
-  resource_prefix         = var.resource_prefix
-  resource_suffix         = var.resource_suffix
-  tags                    = var.tags
+  source                      = "../realtime-visibility/"
+  count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-gov-west-1") ? 1 : 0
+  use_existing_cloudtrail     = var.use_existing_cloudtrail
+  cloudtrail_bucket_name      = local.cloudtrail_bucket_name
+  eventbus_arn                = local.eventbus_arn
+  eventbridge_role_name       = var.eventbridge_role_name
+  is_organization_trail       = length(var.organization_id) > 0
+  is_gov_commercial           = local.is_gov_commercial
+  is_primary_region           = var.primary_region == "us-gov-west-1"
+  primary_region              = var.primary_region
+  realtime_visibility_regions = var.realtime_visibility_regions
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  permissions_boundary        = var.permissions_boundary
+  resource_prefix             = var.resource_prefix
+  resource_suffix             = var.resource_suffix
+  tags                        = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target,

--- a/modules/aws-role/realtime_visibility.tf
+++ b/modules/aws-role/realtime_visibility.tf
@@ -6,10 +6,6 @@ data "aws_regions" "available" {
   }
 }
 
-locals {
-  target_regions = contains(var.realtime_visibility_regions, "all") ? data.aws_regions.available.names : var.realtime_visibility_regions
-}
-
 module "rtvd_us_east_1" {
   source                      = "../realtime-visibility/"
   count                       = (var.enable_realtime_visibility || var.enable_idp) && contains(data.aws_regions.available.names, "us-east-1") ? 1 : 0

--- a/modules/aws-role/variables.tf
+++ b/modules/aws-role/variables.tf
@@ -77,8 +77,8 @@ variable "use_existing_cloudtrail" {
 
 variable "realtime_visibility_regions" {
   type        = list(string)
-  default     = []
-  description = "The list of regions to onboard Realtime Visibility monitoring. Use [\"all\"] to onboard all available regions"
+  default     = ["all"]
+  description = "The list of regions where Real-time visibility and detection should be enabled. Use [\"all\"] to onboard all regions"
 }
 
 variable "enable_idp" {

--- a/modules/realtime-visibility/README.md
+++ b/modules/realtime-visibility/README.md
@@ -117,6 +117,7 @@ module "rules_us_east_2" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudtrail_bucket_name"></a> [cloudtrail\_bucket\_name](#input\_cloudtrail\_bucket\_name) | Name of the S3 bucket for CloudTrail logs | `string` | n/a | yes |
+| <a name="input_create_rules"></a> [create\_rules](#input\_create\_rules) | Set to false if you don't want to enable monitoring in this region | `bool` | `true` | no |
 | <a name="input_eventbridge_role_name"></a> [eventbridge\_role\_name](#input\_eventbridge\_role\_name) | The eventbridge role name | `string` | `"CrowdStrikeCSPMEventBridge"` | no |
 | <a name="input_eventbus_arn"></a> [eventbus\_arn](#input\_eventbus\_arn) | Eventbus ARN to send events to | `string` | n/a | yes |
 | <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API Client ID | `string` | n/a | yes |
@@ -126,7 +127,6 @@ module "rules_us_east_2" {
 | <a name="input_is_primary_region"></a> [is\_primary\_region](#input\_is\_primary\_region) | Whether this is the primary region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. | `bool` | `false` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The name of the policy used to set the permissions boundary for IAM roles | `string` | `""` | no |
 | <a name="input_primary_region"></a> [primary\_region](#input\_primary\_region) | Region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. Distinct from dspm\_regions which controls region-specific resource deployment. | `string` | n/a | yes |
-| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions to onboard Realtime Visibility monitoring. Use ["all"] to onboard all available regions | `list(string)` | <pre>[<br/>  "all"<br/>]</pre> | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix to be added to all resource names | `string` | `""` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to be added to all resource names | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources that support tagging | `map(string)` | `{}` | no |

--- a/modules/realtime-visibility/README.md
+++ b/modules/realtime-visibility/README.md
@@ -126,6 +126,7 @@ module "rules_us_east_2" {
 | <a name="input_is_primary_region"></a> [is\_primary\_region](#input\_is\_primary\_region) | Whether this is the primary region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. | `bool` | `false` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The name of the policy used to set the permissions boundary for IAM roles | `string` | `""` | no |
 | <a name="input_primary_region"></a> [primary\_region](#input\_primary\_region) | Region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. Distinct from dspm\_regions which controls region-specific resource deployment. | `string` | n/a | yes |
+| <a name="input_realtime_visibility_regions"></a> [realtime\_visibility\_regions](#input\_realtime\_visibility\_regions) | The list of regions to onboard Realtime Visibility monitoring. Use ["all"] to onboard all available regions | `list(string)` | <pre>[<br/>  "all"<br/>]</pre> | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix to be added to all resource names | `string` | `""` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to be added to all resource names | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources that support tagging | `map(string)` | `{}` | no |

--- a/modules/realtime-visibility/rules.tf
+++ b/modules/realtime-visibility/rules.tf
@@ -106,13 +106,13 @@ locals {
 }
 
 resource "aws_cloudwatch_event_rule" "rw" {
-  count         = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
+  count         = var.create_rules ? 1 : 0
   name          = local.rule_name
   event_pattern = local.event_pattern
 }
 
 resource "aws_cloudwatch_event_target" "rw" {
-  count     = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
+  count     = var.create_rules ? 1 : 0
   target_id = local.target_id
   arn       = local.eventbus_arn
   rule      = aws_cloudwatch_event_rule.rw[0].name
@@ -125,13 +125,13 @@ resource "aws_cloudwatch_event_target" "rw" {
 
 
 resource "aws_cloudwatch_event_rule" "ro" {
-  count         = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
+  count         = var.create_rules ? 1 : 0
   name          = local.ro_rule_name
   event_pattern = local.ro_event_pattern
 }
 
 resource "aws_cloudwatch_event_target" "ro" {
-  count     = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
+  count     = var.create_rules ? 1 : 0
   target_id = local.target_id
   arn       = local.eventbus_arn
   rule      = aws_cloudwatch_event_rule.ro[0].name

--- a/modules/realtime-visibility/rules.tf
+++ b/modules/realtime-visibility/rules.tf
@@ -106,14 +106,16 @@ locals {
 }
 
 resource "aws_cloudwatch_event_rule" "rw" {
+  count         = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
   name          = local.rule_name
   event_pattern = local.event_pattern
 }
 
 resource "aws_cloudwatch_event_target" "rw" {
+  count     = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
   target_id = local.target_id
   arn       = local.eventbus_arn
-  rule      = aws_cloudwatch_event_rule.rw.name
+  rule      = aws_cloudwatch_event_rule.rw[0].name
   role_arn  = local.eventbridge_role_arn
 
   depends_on = [
@@ -123,14 +125,16 @@ resource "aws_cloudwatch_event_target" "rw" {
 
 
 resource "aws_cloudwatch_event_rule" "ro" {
+  count         = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
   name          = local.ro_rule_name
   event_pattern = local.ro_event_pattern
 }
 
 resource "aws_cloudwatch_event_target" "ro" {
+  count     = contains(var.realtime_visibility_regions, "all") || contains(var.realtime_visibility_regions, local.aws_region) ? 1 : 0
   target_id = local.target_id
   arn       = local.eventbus_arn
-  rule      = aws_cloudwatch_event_rule.ro.name
+  rule      = aws_cloudwatch_event_rule.ro[0].name
   role_arn  = local.eventbridge_role_arn
 
   depends_on = [

--- a/modules/realtime-visibility/variables.tf
+++ b/modules/realtime-visibility/variables.tf
@@ -9,6 +9,12 @@ variable "primary_region" {
   type        = string
 }
 
+variable "realtime_visibility_regions" {
+  type        = list(string)
+  default     = ["all"]
+  description = "The list of regions to onboard Realtime Visibility monitoring. Use [\"all\"] to onboard all available regions"
+}
+
 variable "cloudtrail_bucket_name" {
   type        = string
   description = "Name of the S3 bucket for CloudTrail logs"

--- a/modules/realtime-visibility/variables.tf
+++ b/modules/realtime-visibility/variables.tf
@@ -9,10 +9,10 @@ variable "primary_region" {
   type        = string
 }
 
-variable "realtime_visibility_regions" {
-  type        = list(string)
-  default     = ["all"]
-  description = "The list of regions to onboard Realtime Visibility monitoring. Use [\"all\"] to onboard all available regions"
+variable "create_rules" {
+  type        = bool
+  default     = true
+  description = "Set to false if you don't want to enable monitoring in this region"
 }
 
 variable "cloudtrail_bucket_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -70,10 +70,10 @@ variable "use_existing_cloudtrail" {
   description = "Set to true if you already have a cloudtrail"
 }
 
-variable "realtime_visibility_regions" {
-  type        = list(string)
-  default     = ["all"]
-  description = "The list of regions where Real-time visibility and detection should be enabled. Use [\"all\"] to onboard all regions"
+variable "create_rtvd_rules" {
+  type        = bool
+  default     = true
+  description = "Set to false if you don't want to enable monitoring in this region"
 }
 
 variable "eventbridge_role_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,12 @@ variable "use_existing_cloudtrail" {
   description = "Set to true if you already have a cloudtrail"
 }
 
+variable "realtime_visibility_regions" {
+  type        = list(string)
+  default     = ["all"]
+  description = "The list of regions where Real-time visibility and detection should be enabled. Use [\"all\"] to onboard all regions"
+}
+
 variable "eventbridge_role_name" {
   type        = string
   default     = "CrowdStrikeCSPMEventBridge"


### PR DESCRIPTION
## Problem

Enabling RTVD is some regions (while excluding the primary region) leads to feature not working.
The primary region is used to create the EventBridge role. If RTVD is not enabled in primary region the rules will use a role that doesn't exist.

## Solution
Add `realtime_visibility_regions` variable to explicitly mention RTVD regions or `["all"]` to enable all regions. This will be used for creating EventBridge rules while keeping `enable_realtime_visibility` for creating the role