### PR TITLE
AWS registration: Add new variable to control IAM reader role creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,13 +31,14 @@ locals {
 }
 
 module "asset_inventory" {
-  count                 = local.is_primary_region ? 1 : 0
-  source                = "./modules/asset-inventory/"
-  external_id           = local.external_id
-  intermediate_role_arn = local.intermediate_role_arn
-  role_name             = local.iam_role_name
-  permissions_boundary  = var.permissions_boundary
-  tags                  = var.tags
+  count                        = local.is_primary_region ? 1 : 0
+  source                       = "./modules/asset-inventory/"
+  external_id                  = local.external_id
+  intermediate_role_arn        = local.intermediate_role_arn
+  role_name                    = local.iam_role_name
+  permissions_boundary         = var.permissions_boundary
+  use_existing_iam_reader_role = var.use_existing_iam_reader_role
+  tags                         = var.tags
 
   depends_on = [
     data.crowdstrike_cloud_aws_account.target

--- a/modules/asset-inventory/main.tf
+++ b/modules/asset-inventory/main.tf
@@ -25,6 +25,7 @@ data "aws_iam_policy_document" "this" {
 
 # Create IAM role policy giving the CrowdStrike IAM role read access to AWS resources.
 resource "aws_iam_role" "this" {
+  count                = !var.use_existing_iam_reader_role ? 1 : 0
   name                 = var.role_name
   assume_role_policy   = data.aws_iam_policy_document.this.json
   permissions_boundary = var.permissions_boundary != "" ? "arn:${local.aws_partition}:iam::${local.account_id}:policy/${var.permissions_boundary}" : null
@@ -32,8 +33,9 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy" "this" {
-  name = "cspm_config"
-  role = aws_iam_role.this.id
+  name   = "cspm_config"
+  count  = !var.use_existing_iam_reader_role ? 1 : 0
+  role   = aws_iam_role.this[count.index].id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -154,6 +156,7 @@ resource "aws_iam_role_policy" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
-  role       = aws_iam_role.this.name
+  count      = !var.use_existing_iam_reader_role ? 1 : 0
+  role       = aws_iam_role.this[count.index].name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/SecurityAudit"
 }

--- a/modules/asset-inventory/outputs.tf
+++ b/modules/asset-inventory/outputs.tf
@@ -1,4 +1,4 @@
 output "reader_role_arn" {
-  value       = aws_iam_role.this.arn
+  value       = aws_iam_role.this[*].arn
   description = "The reader role ARN used for asset inventory"
 }

--- a/modules/asset-inventory/variables.tf
+++ b/modules/asset-inventory/variables.tf
@@ -3,6 +3,12 @@ variable "external_id" {
   description = "Unique identifier provided by CrowdStrike for secure cross-account access"
 }
 
+variable "use_existing_iam_reader_role" {
+  type = bool
+  default = false
+  description = "Set to true if you intend to use an existing IAM role for asset inventory"
+}
+
 variable "role_name" {
   type        = string
   description = "Name of the asset inventory reader IAM role"

--- a/modules/aws-profile/main.tf
+++ b/modules/aws-profile/main.tf
@@ -28,12 +28,13 @@ locals {
 }
 
 module "asset_inventory" {
-  source                = "../asset-inventory/"
-  external_id           = local.external_id
-  intermediate_role_arn = local.intermediate_role_arn
-  role_name             = local.iam_role_name
-  permissions_boundary  = var.permissions_boundary
-  tags                  = var.tags
+  source                       = "../asset-inventory/"
+  external_id                  = local.external_id
+  intermediate_role_arn        = local.intermediate_role_arn
+  role_name                    = local.iam_role_name
+  use_existing_iam_reader_role = var.use_existing_iam_reader_role
+  permissions_boundary         = var.permissions_boundary
+  tags                         = var.tags
 
   providers = {
     aws = aws

--- a/modules/aws-profile/variables.tf
+++ b/modules/aws-profile/variables.tf
@@ -105,6 +105,12 @@ variable "iam_role_name" {
   description = "The name of the reader role"
 }
 
+variable "use_existing_iam_reader_role" {
+  type        = bool
+  default     = false
+  description = "Set to true if you want to use an existing IAM role for asset inventory"
+}
+
 variable "eventbus_arn" {
   type        = string
   default     = ""

--- a/modules/aws-role/main.tf
+++ b/modules/aws-role/main.tf
@@ -43,12 +43,13 @@ locals {
 }
 
 module "asset_inventory" {
-  source                = "../asset-inventory/"
-  external_id           = local.external_id
-  intermediate_role_arn = local.intermediate_role_arn
-  role_name             = local.iam_role_name
-  permissions_boundary  = var.permissions_boundary
-  tags                  = var.tags
+  source                       = "../asset-inventory/"
+  external_id                  = local.external_id
+  intermediate_role_arn        = local.intermediate_role_arn
+  role_name                    = local.iam_role_name
+  use_existing_iam_reader_role = var.use_existing_iam_reader_role
+  permissions_boundary         = var.permissions_boundary
+  tags                         = var.tags
 
   providers = {
     aws = aws

--- a/modules/aws-role/variables.tf
+++ b/modules/aws-role/variables.tf
@@ -105,6 +105,12 @@ variable "iam_role_name" {
   description = "The name of the reader role"
 }
 
+variable "use_existing_iam_reader_role" {
+  type        = bool
+  default     = false
+  description = "Set to true if you want to use an existing IAM role for asset inventory"
+}
+
 variable "eventbus_arn" {
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,12 @@ variable "iam_role_name" {
   description = "The name of the reader role"
 }
 
+variable "use_existing_iam_reader_role" {
+  type        = bool
+  default     = false
+  description = "Set to true if you want to use an existing IAM role for asset inventory"
+}
+
 variable "eventbus_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
Adding a new option to control IAM reader role creation for users who would like to use existing IAM roles for asset inventory