### PR TITLE
fix: correct typo in CloudWatch event pattern exclusion

### DIFF
--- a/modules/realtime-visibility/rules.tf
+++ b/modules/realtime-visibility/rules.tf
@@ -62,7 +62,7 @@ locals {
                 "HeadObject",
                 "ListObjects",
                 "GetObjectTagging",
-                "GetOjectAcl",
+                "GetObjectAcl",
                 "AssumeRole"
               ]
             }


### PR DESCRIPTION
Change "GetOjectAcl" to "GetObjectAcl" in CloudWatch event rule patterns
for CrowdStrike real-time visibility monitoring across all regions.

This ensures proper filtering of S3 GetObjectAcl events from CrowdStrike
event processing.

Fixes #21
