### PR TITLE
feature/dspm-scanner-remove-ssm-permissions

### DIFF
--- a/modules/dspm-roles/main.tf
+++ b/modules/dspm-roles/main.tf
@@ -39,12 +39,6 @@ resource "aws_iam_role_policy_attachment" "cloud_watch_logs_read_only_access" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess"
 }
 
-resource "aws_iam_role_policy_attachment" "amazon_ssm_managed_instance_core" {
-  role       = aws_iam_role.crowdstrike_aws_dspm_scanner_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-
 
 resource "aws_iam_role_policy" "crowdstrike_logs_reader" {
   #checkov:skip=CKV_AWS_355:DSPM data scanner requires read access to logs for all scannable assets


### PR DESCRIPTION
Removing AWS SSM permissions for DSPM scanner role