### PR TITLE
added github codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners
+* @CrowdStrike/fcs-engineering


### PR DESCRIPTION
Add GitHub CODEOWNERS file to designate FCS Engineering team as code owners for all repository files

I created a pull request to demonstrate the codeowners behavior - 
https://github.com/CrowdStrike/terraform-aws-cloud-registration/pull/59

<img width="337" height="171" alt="image" src="https://github.com/user-attachments/assets/d43f7e37-dc08-4573-9995-8f6796a7e459" />
