### PR TITLE
use id instead of region or name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "crowdstrike_cloud_aws_account" "target" {
 }
 
 locals {
-  aws_region        = data.aws_region.current.region
+  aws_region        = data.aws_region.current.id
   is_primary_region = local.aws_region == var.primary_region
   is_gov_commercial = var.is_gov && var.account_type == "commercial"
 

--- a/modules/dspm-environments/locals.tf
+++ b/modules/dspm-environments/locals.tf
@@ -10,6 +10,6 @@ locals {
   logical_ec2_security_group    = "EC2SecurityGroup"
   logical_db_security_group     = "DBSecurityGroup"
   logical_kms_key               = "KMSKey"
-  aws_region                    = data.aws_region.current.region
+  aws_region                    = data.aws_region.current.id
   account_id                    = data.aws_caller_identity.current.account_id
 }

--- a/modules/realtime-visibility/main.tf
+++ b/modules/realtime-visibility/main.tf
@@ -4,7 +4,7 @@ data "aws_partition" "current" {}
 
 locals {
   account_id    = data.aws_caller_identity.current.account_id
-  aws_region    = data.aws_region.current.region
+  aws_region    = data.aws_region.current.id
   aws_partition = data.aws_partition.current.partition
 }
 

--- a/modules/sensor-management/main.tf
+++ b/modules/sensor-management/main.tf
@@ -4,7 +4,7 @@ data "aws_partition" "current" {}
 
 locals {
   account_id    = data.aws_caller_identity.current.account_id
-  aws_region    = data.aws_region.current.region
+  aws_region    = data.aws_region.current.id
   aws_partition = data.aws_partition.current.partition
 }
 


### PR DESCRIPTION
`.name` is depreciated in v6 and `.region` does not exist in versions <6. ID can be used in all versions.