### PR TITLE
Update CrowdStrike provider minimum version to 0.0.58:CSPG-8204

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/docs/.usage.tf
+++ b/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/examples/org-aws-profile/versions.tf
+++ b/examples/org-aws-profile/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/examples/org-aws-role/versions.tf
+++ b/examples/org-aws-role/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/examples/single-account-aws-profile/versions.tf
+++ b/examples/single-account-aws-profile/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/examples/single-account-aws-role/versions.tf
+++ b/examples/single-account-aws-role/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/examples/single-account/versions.tf
+++ b/examples/single-account/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/agentless-scanning-environments/README.md
+++ b/modules/agentless-scanning-environments/README.md
@@ -21,7 +21,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/agentless-scanning-environments/docs/.usage.tf
+++ b/modules/agentless-scanning-environments/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/agentless-scanning-roles/README.md
+++ b/modules/agentless-scanning-roles/README.md
@@ -19,7 +19,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/agentless-scanning-roles/docs/.usage.tf
+++ b/modules/agentless-scanning-roles/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/asset-inventory/README.md
+++ b/modules/asset-inventory/README.md
@@ -19,7 +19,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/asset-inventory/docs/.usage.tf
+++ b/modules/asset-inventory/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/aws-profile/README.md
+++ b/modules/aws-profile/README.md
@@ -71,7 +71,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/aws-profile/docs/.usage.tf
+++ b/modules/aws-profile/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/aws-profile/versions.tf
+++ b/modules/aws-profile/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/aws-role/README.md
+++ b/modules/aws-role/README.md
@@ -71,7 +71,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/aws-role/docs/.usage.tf
+++ b/modules/aws-role/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/aws-role/versions.tf
+++ b/modules/aws-role/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/realtime-visibility/README.md
+++ b/modules/realtime-visibility/README.md
@@ -19,7 +19,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/realtime-visibility/docs/.usage.tf
+++ b/modules/realtime-visibility/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/sensor-management/README.md
+++ b/modules/sensor-management/README.md
@@ -19,7 +19,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/modules/sensor-management/docs/.usage.tf
+++ b/modules/sensor-management/docs/.usage.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.44"
+      version = ">= 0.0.58"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -7,7 +7,7 @@ terraform {
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"
-      version = ">= 0.0.51"
+      version = ">= 0.0.58"
     }
   }
 }


### PR DESCRIPTION
Updated the crowdstrike provider minimum version to 0.0.58
This provider version deprecated cspmregistration APIs
