### PR TITLE
Include consistent resource prefixes

### DIFF
--- a/examples/org-aws-profile/main.tf
+++ b/examples/org-aws-profile/main.tf
@@ -13,6 +13,8 @@ locals {
   dspm_rds_access                       = var.dspm_rds_access
   dspm_redshift_access                  = var.dspm_redshift_access
   dspm_ebs_access                       = var.dspm_ebs_access
+  resource_prefix                       = "cs-"
+  resource_suffix                       = "-cspm"
 }
 
 provider "crowdstrike" {
@@ -22,9 +24,10 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id      = var.account_id
-  organization_id = var.organization_id
-
+  account_id           = var.account_id
+  organization_id      = var.organization_id
+  resource_name_prefix = local.resource_prefix
+  resource_name_suffix = local.resource_suffix
   asset_inventory = {
     enabled = true
   }

--- a/examples/org-aws-role/main.tf
+++ b/examples/org-aws-role/main.tf
@@ -13,6 +13,8 @@ locals {
   dspm_rds_access                       = var.dspm_rds_access
   dspm_redshift_access                  = var.dspm_redshift_access
   dspm_ebs_access                       = var.dspm_ebs_access
+  resource_prefix                       = "cs-"
+  resource_suffix                       = "-cspm"
 }
 
 provider "crowdstrike" {
@@ -22,9 +24,10 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id      = var.account_id
-  organization_id = var.organization_id
-
+  account_id           = var.account_id
+  organization_id      = var.organization_id
+  resource_name_prefix = local.resource_prefix
+  resource_name_suffix = local.resource_suffix
   asset_inventory = {
     enabled = true
   }

--- a/examples/single-account-aws-profile/main.tf
+++ b/examples/single-account-aws-profile/main.tf
@@ -36,8 +36,9 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id = var.account_id
-
+  account_id           = var.account_id
+  resource_name_prefix = local.resource_prefix
+  resource_name_suffix = local.resource_suffix
   asset_inventory = {
     enabled   = true
     role_name = local.custom_role_name

--- a/examples/single-account-aws-role/main.tf
+++ b/examples/single-account-aws-role/main.tf
@@ -36,8 +36,9 @@ provider "crowdstrike" {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id = var.account_id
-
+  account_id           = var.account_id
+  resource_name_prefix = local.resource_prefix
+  resource_name_suffix = local.resource_suffix
   asset_inventory = {
     enabled   = true
     role_name = local.custom_role_name

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -54,8 +54,9 @@ locals {
 
 # Provision AWS account in Falcon.
 resource "crowdstrike_cloud_aws_account" "this" {
-  account_id = var.account_id
-
+  account_id           = var.account_id
+  resource_name_prefix = local.resource_prefix
+  resource_name_suffix = local.resource_suffix
   asset_inventory = {
     enabled   = true
     role_name = local.custom_role_name


### PR DESCRIPTION
Add resource prefixes into "crowdstrike_cloud_aws_account"
Use the same prefix and suffix across examples

Fixes #96 