### PR TITLE
fix(CSPG-84526): pass account_type to sensor_management module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ module "sensor_management" {
   external_id           = local.external_id
   intermediate_role_arn = local.intermediate_role_arn
   permissions_boundary  = var.permissions_boundary
+  account_type          = var.account_type
   resource_prefix       = var.resource_prefix
   resource_suffix       = var.resource_suffix
   tags                  = var.tags


### PR DESCRIPTION
## Summary
- Passes `account_type` from the root module to the `sensor_management` sub-module
- Without this, the sensor management module defaults to `"commercial"`, causing GovCloud deployments to fail with `Unsupported AWS region "us-gov-west-1"` because the `region_map` module doesn't support gov regions
- The sensor management module already uses `account_type` to skip `region_map` and use GovCloud-specific S3 buckets for Lambda packages

## Test plan
- [x] Deploy with a GovCloud account targeting GovCloud Falcon and confirm sensor management provisions without the `region_map` precondition error
- [x] Deploy with a commercial account and confirm no regression (default `account_type` = `"commercial"` behavior unchanged)

Fixes: CSPG-84526