### PR TITLE
Update min hashicorp aws provider version to 5.26 to support al.2023 lambda runtime

### DIFF
--- a/docs/.usage.tf
+++ b/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/examples/org-aws-profile/versions.tf
+++ b/examples/org-aws-profile/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/examples/org-aws-role/versions.tf
+++ b/examples/org-aws-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/examples/single-account-aws-profile/versions.tf
+++ b/examples/single-account-aws-profile/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/examples/single-account-aws-role/versions.tf
+++ b/examples/single-account-aws-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/examples/single-account/versions.tf
+++ b/examples/single-account/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/agentless-scanning-environments/docs/.usage.tf
+++ b/modules/agentless-scanning-environments/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/agentless-scanning-environments/versions.tf
+++ b/modules/agentless-scanning-environments/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
   }
 }

--- a/modules/agentless-scanning-roles/docs/.usage.tf
+++ b/modules/agentless-scanning-roles/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/agentless-scanning-roles/versions.tf
+++ b/modules/agentless-scanning-roles/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
   }
 }

--- a/modules/asset-inventory/docs/.usage.tf
+++ b/modules/asset-inventory/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/asset-inventory/versions.tf
+++ b/modules/asset-inventory/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
   }
 }

--- a/modules/aws-profile/docs/.usage.tf
+++ b/modules/aws-profile/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/aws-profile/versions.tf
+++ b/modules/aws-profile/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/aws-role/docs/.usage.tf
+++ b/modules/aws-role/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/aws-role/versions.tf
+++ b/modules/aws-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/realtime-visibility/docs/.usage.tf
+++ b/modules/realtime-visibility/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/realtime-visibility/versions.tf
+++ b/modules/realtime-visibility/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/sensor-management/docs/.usage.tf
+++ b/modules/sensor-management/docs/.usage.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"

--- a/modules/sensor-management/versions.tf
+++ b/modules/sensor-management/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.26.0"
     }
     crowdstrike = {
       source  = "CrowdStrike/crowdstrike"


### PR DESCRIPTION
Update min hashicorp aws provider version to 5.26 to support al.2023 lambda runtime