### PR TITLE
fix(cloudregistration) - add eagle env vars to 1click Lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,6 +91,8 @@ module "sensor_management" {
   intermediate_role_arn = local.intermediate_role_arn
   permissions_boundary  = var.permissions_boundary
   account_type          = var.account_type
+  is_gov                = var.is_gov
+  cs_address            = var.cs_address
   resource_prefix       = var.resource_prefix
   resource_suffix       = var.resource_suffix
   tags                  = var.tags

--- a/modules/sensor-management/main.tf
+++ b/modules/sensor-management/main.tf
@@ -161,11 +161,17 @@ resource "aws_lambda_function" "this" {
   s3_key    = local.lambda_s3_key
 
   environment {
-    variables = {
-      CS_CLIENT_ID                  = var.falcon_client_id
-      CS_API_CREDENTIALS_AWS_SECRET = aws_secretsmanager_secret.this.name
-      CS_MODE                       = "force_auth"
-    }
+    variables = merge(
+      {
+        CS_CLIENT_ID                  = var.falcon_client_id
+        CS_API_CREDENTIALS_AWS_SECRET = aws_secretsmanager_secret.this.name
+        CS_MODE                       = "force_auth"
+      },
+      var.is_gov ? {
+        CS_GOV_CLOUD = "true"
+        CS_ADDRESS   = var.cs_address
+      } : {}
+    )
   }
 
   depends_on = [aws_cloudwatch_log_group.crowdstrike_sensor_management]

--- a/modules/sensor-management/variables.tf
+++ b/modules/sensor-management/variables.tf
@@ -53,3 +53,15 @@ variable "account_type" {
     error_message = "must be either 'commercial' or 'gov'"
   }
 }
+
+variable "is_gov" {
+  type        = bool
+  default     = false
+  description = "Set to true if deploying in a gov Falcon environment (eagle, merlin)"
+}
+
+variable "cs_address" {
+  type        = string
+  default     = ""
+  description = "CrowdStrike Falcon address for the Lambda to authenticate against (e.g. az.laggar.gcw.crowdstrike.com:443)"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "is_gov" {
   description = "Set to true if you are deploying in gov Falcon"
 }
 
+variable "cs_address" {
+  type        = string
+  default     = ""
+  description = "CrowdStrike Falcon address for sensor management Lambda (e.g. az.laggar.gcw.crowdstrike.com:443). Required when is_gov = true."
+}
+
 variable "primary_region" {
   description = "Region for deploying global AWS resources (IAM roles, policies, etc.) that are account-wide and only need to be created once. Distinct from agentless_scanning_regions which controls region-specific resource deployment."
   type        = string


### PR DESCRIPTION
## Summary
- Add `cs_address` variable to the root module and sensor-management submodule
- When `is_gov = true`, the sensor management Lambda receives `CS_GOV_CLOUD=true` and `CS_ADDRESS` env vars via conditional `merge()`
- When `is_gov = false` (default), Lambda environment is unchanged — no regression for commercial deployments

## Motivation
The sensor management Lambda in gov Falcon environments (Eagle) cannot authenticate because it has no way to know the Falcon API endpoint. This adds the necessary env vars so 1-Click Sensor Management can function for accounts registered in Eagle.
