### PR TITLE
fix: pass "permission_boundary" to "realtime_visibility module"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ module "realtime_visibility" {
   is_primary_region       = local.is_primary_region
   create_rules            = var.create_rtvd_rules
   primary_region          = var.primary_region
+  permissions_boundary    = var.permissions_boundary
   falcon_client_id        = var.falcon_client_id
   falcon_client_secret    = var.falcon_client_secret
   resource_prefix         = var.resource_prefix


### PR DESCRIPTION
## Problem

When a customer's AWS environment requires a permissions boundary on all IAM
role creation, deploying the realtime-visibility module fails with an explicit
deny. The `realtime_visibility` child module accepts a `permissions_boundary`
variable, but `main.tf` never passes the value through from the root module,
so IAM roles are created without a boundary attached.

Error seen in customer environments:

```
User: ... is not authorized to perform: iam:CreateRole on resource: ...
with an explicit deny in a permissions boundary: ...
```

Reference: SUPPORT-53320

## Solution

Pass `var.permissions_boundary` through to the `realtime_visibility` module
call in `main.tf`. No new variables or module changes are required; this is
a missing wire-up.
