### PR TITLE
fix: add permissions_boundary support to agentless-scanning-roles module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -166,6 +166,7 @@ module "agentless_scanning_roles" {
   account_id                                  = local.aws_account
   agentless_scanning_host_account_id          = var.agentless_scanning_host_account_id
   agentless_scanning_host_scanner_role_name   = var.agentless_scanning_host_scanner_role_name
+  permissions_boundary                        = var.permissions_boundary
 }
 
 module "agentless_scanning_environments" {

--- a/modules/agentless-scanning-roles/integration_role.tf
+++ b/modules/agentless-scanning-roles/integration_role.tf
@@ -26,6 +26,7 @@ resource "aws_iam_role" "crowdstrike_aws_agentless_scanning_integration_role" {
   path                 = "/"
   max_session_duration = 43200
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = local.permissions_boundary_arn
   tags = merge(
     var.tags,
     {

--- a/modules/agentless-scanning-roles/integration_role.tf
+++ b/modules/agentless-scanning-roles/integration_role.tf
@@ -26,7 +26,7 @@ resource "aws_iam_role" "crowdstrike_aws_agentless_scanning_integration_role" {
   path                 = "/"
   max_session_duration = 43200
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
-  permissions_boundary = local.permissions_boundary_arn
+  permissions_boundary = var.permissions_boundary != "" ? "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}" : null
   tags = merge(
     var.tags,
     {

--- a/modules/agentless-scanning-roles/locals.tf
+++ b/modules/agentless-scanning-roles/locals.tf
@@ -6,8 +6,6 @@ locals {
 
   aws_partition = data.aws_partition.current.partition
 
-  permissions_boundary_arn = var.permissions_boundary != "" ? "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}" : null
-
   # Extract VPC ARNs from custom VPC resources map for IAM policy conditions
   custom_vpc_arns = [
     for region, resources in var.agentless_scanning_custom_vpc_resources_map :

--- a/modules/agentless-scanning-roles/locals.tf
+++ b/modules/agentless-scanning-roles/locals.tf
@@ -6,6 +6,8 @@ locals {
 
   aws_partition = data.aws_partition.current.partition
 
+  permissions_boundary_arn = var.permissions_boundary != "" ? "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}" : null
+
   # Extract VPC ARNs from custom VPC resources map for IAM policy conditions
   custom_vpc_arns = [
     for region, resources in var.agentless_scanning_custom_vpc_resources_map :

--- a/modules/agentless-scanning-roles/main.tf
+++ b/modules/agentless-scanning-roles/main.tf
@@ -17,7 +17,7 @@ resource "aws_ssm_parameter" "agentless_scanning_root_parameter" {
   type = "String"
   tier = "Intelligent-Tiering"
   value = jsonencode({
-    version            = "1.1.0+tf.0"
+    version            = "1.1.1+tf.0"
     deployment_regions = var.agentless_scanning_regions
     scan_products = {
       dspm_scanning_enabled          = var.enable_dspm

--- a/modules/agentless-scanning-roles/main.tf
+++ b/modules/agentless-scanning-roles/main.tf
@@ -79,6 +79,7 @@ resource "aws_iam_role" "crowdstrike_aws_agentless_scanning_scanner_role" {
       }
     ]
   })
+  permissions_boundary = local.permissions_boundary_arn
   tags = merge(
     var.tags,
     {

--- a/modules/agentless-scanning-roles/main.tf
+++ b/modules/agentless-scanning-roles/main.tf
@@ -79,7 +79,7 @@ resource "aws_iam_role" "crowdstrike_aws_agentless_scanning_scanner_role" {
       }
     ]
   })
-  permissions_boundary = local.permissions_boundary_arn
+  permissions_boundary = var.permissions_boundary != "" ? "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.permissions_boundary}" : null
   tags = merge(
     var.tags,
     {

--- a/modules/agentless-scanning-roles/variables.tf
+++ b/modules/agentless-scanning-roles/variables.tf
@@ -138,6 +138,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "permissions_boundary" {
+  description = "The name of the policy used to set the permissions boundary for IAM roles"
+  type        = string
+  default     = ""
+}
+
 variable "agentless_scanning_host_account_id" {
   type        = string
   default     = ""


### PR DESCRIPTION
## Problem

When a customer's AWS environment requires a permissions boundary on all IAM role creation, deploying the agentless-scanning-roles module fails with an explicit deny. Unlike the other modules, agentless-scanning-roles does not accept a `permissions_boundary` variable at all, so the integration and scanner IAM roles are always created without a boundary attached.

Reference: SUPPORT-53626

## Solution

Add a `permissions_boundary` support to the agentless-scanning-roles module.