### PR TITLE
fix: enable CloudTrail log file validation

### DIFF
--- a/modules/realtime-visibility/main.tf
+++ b/modules/realtime-visibility/main.tf
@@ -81,6 +81,7 @@ resource "aws_cloudtrail" "this" {
   include_global_service_events = true
   is_multi_region_trail         = true
   enable_logging                = true
+  enable_log_file_validation    = true
   is_organization_trail         = var.is_organization_trail
   tags                          = var.tags
 }


### PR DESCRIPTION
## Description

Enable CloudTrail log-file validation for trails created by the real-time visibility module. This causes AWS to generate digest files so consumers can verify the integrity of delivered CloudTrail logs.

This is an IOM that Crowdstrike raise with RuleID 7858fee3-9e6c-40f8-9c34-c7c4eb49dd65

## Validation

- `terraform fmt -check -recursive`
- `terraform validate`